### PR TITLE
Add setup script to share logic with prow

### DIFF
--- a/Dockerfile.image-service-build
+++ b/Dockerfile.image-service-build
@@ -2,8 +2,5 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.16
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 
-RUN yum install -y podman && \
-    yum clean all
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
-RUN go get -u golang.org/x/tools/cmd/goimports@v0.1.5 \
-              github.com/golang/mock/mockgen@v1.6.0
+COPY hack/setup_env.sh ./
+RUN ./setup_env.sh

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ PORT := $(or ${PORT}, 8080)
 build:
 	podman build -f Dockerfile.image-service . -t $(IMAGE)
 
+build-openshift-ci-test-bin:
+	./hack/setup_env.sh
+
 lint:
 	golangci-lint run -v
 

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+yum install -y install podman genisoimage && yum clean all
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
+go get -u golang.org/x/tools/cmd/goimports@v0.1.5 github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
Both the prow test container and our build container will need to
install the same test dependencies and we want to keep those as similar
as possible.

After this is merged, the prow test-bin container will call the new
`build-openshift-ci-test-bin` make target to ensure our dependencies are
installed

This also adds the `genisoimage` command in preparation of the tests
from the iso editing code.

Required for https://github.com/openshift/assisted-image-service/pull/5 to pass tests

cc @lranjbar 