### PR TITLE
Clean up test setup duplication

### DIFF
--- a/pkg/isoeditor/isoeditor_suite_test.go
+++ b/pkg/isoeditor/isoeditor_suite_test.go
@@ -1,6 +1,9 @@
-package isoeditor_test
+package isoeditor
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -10,4 +13,52 @@ import (
 func TestIsoEditor(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "IsoEditor")
+}
+
+const testGrubConfig = `
+menuentry 'RHEL CoreOS (Live)' --class fedora --class gnu-linux --class gnu --class os {
+	linux /images/pxeboot/vmlinuz random.trust_cpu=on rd.luks.options=discard coreos.liveiso=rhcos-46.82.202010091720-0 ignition.firstboot ignition.platform.id=metal
+	initrd /images/pxeboot/initrd.img /images/ignition.img
+}
+`
+
+const testISOLinuxConfig = `
+label linux
+  menu label ^RHEL CoreOS (Live)
+  menu default
+  kernel /images/pxeboot/vmlinuz
+  append initrd=/images/pxeboot/initrd.img,/images/ignition.img random.trust_cpu=on rd.luks.options=discard coreos.liveiso=rhcos-46.82.202010091720-0 ignition.firstboot ignition.platform.id=metal
+`
+
+func createTestFiles(volumeID string) (string, string) {
+	filesDir, err := os.MkdirTemp("", "isotest")
+	Expect(err).ToNot(HaveOccurred())
+
+	temp, err := os.CreateTemp("", "*test.iso")
+	Expect(err).ToNot(HaveOccurred())
+
+	isoFile := temp.Name()
+	Expect(temp.Close()).To(Succeed())
+	Expect(os.Remove(temp.Name())).To(Succeed())
+
+	Expect(os.MkdirAll(filepath.Join(filesDir, "images/pxeboot"), 0755)).To(Succeed())
+	Expect(os.MkdirAll(filepath.Join(filesDir, "EFI/redhat"), 0755)).To(Succeed())
+	Expect(os.MkdirAll(filepath.Join(filesDir, "isolinux"), 0755)).To(Succeed())
+
+	// Create a file with some size to test load sector calculation
+	f, err := os.Create(filepath.Join(filesDir, "images", "efiboot.img"))
+	Expect(err).ToNot(HaveOccurred())
+	Expect(f.Truncate(8184422)).To(Succeed())
+
+	Expect(os.WriteFile(filepath.Join(filesDir, "images/assisted_installer_custom.img"), make([]byte, RamDiskPaddingLength), 0600)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(filesDir, "images/ignition.img"), make([]byte, ignitionPaddingLength), 0600)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(filesDir, "images/pxeboot/rootfs.img"), []byte("this is rootfs"), 0600)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(filesDir, "EFI/redhat/grub.cfg"), []byte(testGrubConfig), 0600)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(filesDir, "isolinux/isolinux.cfg"), []byte(testISOLinuxConfig), 0600)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(filesDir, "isolinux/boot.cat"), []byte(""), 0600)).To(Succeed())
+
+	cmd := exec.Command("genisoimage", "-rational-rock", "-J", "-joliet-long", "-V", volumeID, "-o", isoFile, filesDir)
+	Expect(cmd.Run()).To(Succeed())
+
+	return filesDir, isoFile
 }


### PR DESCRIPTION
Both isoutil_test and rhcos_test need an iso and some test files.
There were slight differences between what was being used, but there's
no reason this setup can't be shared.

This commit DRYs up the setup for these test files and also removes some
global state from the rhcos tests.