### PR TITLE
MGMT-7499 Take an auth token as a query parameter and pass it to assisted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,14 @@ format:
 	@goimports -w -l main.go internal pkg || /bin/true
 
 run: certs
-	podman run --rm -v $(PWD)/data:/data:Z -v $(PWD)/certs:/certs:Z -p$(PORT):$(PORT) -e PORT=$(PORT) -e HTTPS_KEY_FILE=/certs/tls.key -e HTTPS_CERT_FILE=/certs/tls.crt -e ASSISTED_SERVICE_SCHEME=${ASSISTED_SERVICE_SCHEME} -e ASSISTED_SERVICE_HOST=${ASSISTED_SERVICE_HOST} $(IMAGE)
+	podman run --rm \
+		-v $(PWD)/data:/data:Z -v $(PWD)/certs:/certs:Z \
+		-p$(PORT):$(PORT) \
+		-e PORT=$(PORT) \
+		-e HTTPS_KEY_FILE=/certs/tls.key -e HTTPS_CERT_FILE=/certs/tls.crt \
+		-e ASSISTED_SERVICE_SCHEME=${ASSISTED_SERVICE_SCHEME} -e ASSISTED_SERVICE_HOST=${ASSISTED_SERVICE_HOST} \
+		-e REQUEST_AUTH_TYPE=${REQUEST_AUTH_TYPE} \
+		$(IMAGE)
 
 .PHONY: certs
 certs:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ skipper make test
 - `PORT` - Service listen port
 - `HTTPS_KEY_FILE` - tls key file path
 - `HTTPS_CERT_FILE` - tls cert file path
-- `ASSISTED_SERVICE_URL` - URL to use to query assisted service for image information
+- `ASSISTED_SERVICE_SCHEME` - protocol to use to query assisted service for image information
+- `ASSISTED_SERVICE_HOST` - host to use to query assisted service for image information
+- `REQUEST_AUTH_TYPE` - determines how the auth token should be passed to the assisted service - either `header` or `param`
+  - For `header` a header of the form `Authorization: Bearer <token>` is used
+  - For `param` an `api_key=<token>` query parameter is added to the URL
 
 Example `RHCOS_VERSIONS`:
 ```json
@@ -57,6 +61,7 @@ Downloads the RHCOS image for the specified image ID.
 
 `version`: indicates the version of the RHCOS base image to use (must match a key in `RHCOS_VERSIONS`)
 `type`: `full` to download the ISO including the rootfs, `minimal` to download the iso without the rootfs
+`api_key`: the api token to pass through to the assisted service calls if authentication is required
 
 ### `GET /health`
 

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
 	"github.com/openshift/assisted-image-service/pkg/imagestore"
 )
 
@@ -23,138 +24,220 @@ func TestHandlers(t *testing.T) {
 
 var _ = Describe("ServeHTTP", func() {
 	var (
-		ctrl              *gomock.Controller
-		mockImageStore    *imagestore.MockImageStore
-		server            *httptest.Server
-		assistedServer    *httptest.Server
-		client            *http.Client
-		fullImageFilename string
-		minImageFilename  string
-		imageID           = "bf25292a-dddd-49dc-ab9c-3fb4c1f07071"
+		ctrl                 *gomock.Controller
+		mockImageStore       *imagestore.MockImageStore
+		fullImageFilename    string
+		minImageFilename     string
+		imageID              = "bf25292a-dddd-49dc-ab9c-3fb4c1f07071"
+		assistedServer       *ghttp.Server
+		ignitionContent      = "someignitioncontent"
+		ignitionArchiveBytes = []byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 50, 48, 55, 48, 55, 48, 52, 128, 0, 48, 109, 97, 232, 104, 98, 128, 29, 24, 162, 113, 141, 113, 168, 67, 7, 78, 48, 70, 114, 126, 94, 90, 102, 186, 94, 102, 122, 30, 3, 3, 3, 67, 113, 126, 110, 106, 102, 122, 94, 102, 73, 102, 126, 94, 114, 126, 94, 73, 106, 94, 9, 3, 138, 123, 8, 1, 98, 213, 225, 116, 79, 72, 144, 163, 167, 143, 107, 144, 162, 162, 34, 200, 61, 128, 0, 0, 0, 255, 255, 191, 236, 44, 242, 12, 1, 0, 0}
 	)
 
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		mockImageStore = imagestore.NewMockImageStore(ctrl)
+	Context("with image files", func() {
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			mockImageStore = imagestore.NewMockImageStore(ctrl)
 
-		serveIgnitionFunc := func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			Expect(r.URL.Path).To(Equal(fmt.Sprintf("/api/assisted-install/v1/clusters/%s/downloads/files", imageID)))
-			Expect(r.URL.RawQuery).To(Equal("file_name=discovery.ign"))
-			_, err := io.WriteString(w, "someignitioncontent")
+			fullImageFile, err := os.CreateTemp("", "image_handler_test")
 			Expect(err).NotTo(HaveOccurred())
+			_, err = fullImageFile.Write([]byte("someisocontent"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fullImageFile.Sync()).To(Succeed())
+			Expect(fullImageFile.Close()).To(Succeed())
+			fullImageFilename = fullImageFile.Name()
+
+			minImageFile, err := os.CreateTemp("", "image_handler_test")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = minImageFile.Write([]byte("minimalisocontent"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(minImageFile.Sync()).To(Succeed())
+			Expect(minImageFile.Close()).To(Succeed())
+			minImageFilename = minImageFile.Name()
+
+			assistedServer = ghttp.NewServer()
+		})
+
+		AfterEach(func() {
+			assistedServer.Close()
+			os.Remove(fullImageFilename)
+			os.Remove(minImageFilename)
+		})
+
+		mockImage := func(version, imageType string) {
+			mockImageStore.EXPECT().HaveVersion(version).Return(true).AnyTimes()
+
+			var imageFile string
+			switch imageType {
+			case imagestore.ImageTypeFull:
+				imageFile = fullImageFilename
+			case imagestore.ImageTypeMinimal:
+				imageFile = minImageFilename
+			default:
+				Fail("cannot mock with an unsupported image type")
+			}
+			mockImageStore.EXPECT().BaseFile(version, imageType).Return(imageFile, nil).AnyTimes()
 		}
 
-		assistedServer = httptest.NewServer(http.HandlerFunc(serveIgnitionFunc))
-		u, err := url.Parse(assistedServer.URL)
-		Expect(err).NotTo(HaveOccurred())
-
-		ignitionArchiveBytes := []byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 50, 48, 55, 48, 55, 48, 52, 128, 0, 48, 109, 97, 232, 104, 98, 128, 29, 24, 162, 113, 141, 113, 168, 67, 7, 78, 48, 70, 114, 126, 94, 90, 102, 186, 94, 102, 122, 30, 3, 3, 3, 67, 113, 126, 110, 106, 102, 122, 94, 102, 73, 102, 126, 94, 114, 126, 94, 73, 106, 94, 9, 3, 138, 123, 8, 1, 98, 213, 225, 116, 79, 72, 144, 163, 167, 143, 107, 144, 162, 162, 34, 200, 61, 128, 0, 0, 0, 255, 255, 191, 236, 44, 242, 12, 1, 0, 0}
-
-		mockImageStream := func(isoPath string, ignitionContent []byte) (io.ReadSeeker, error) {
-			defer GinkgoRecover()
-			Expect(ignitionContent).To(Equal(ignitionArchiveBytes))
-			return os.Open(isoPath)
+		expectSuccessfulResponse := func(resp *http.Response, content []byte) {
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			respContent, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(respContent).To(Equal(content))
 		}
 
-		handler := &ImageHandler{
-			ImageStore:            mockImageStore,
-			GenerateImageStream:   mockImageStream,
-			AssistedServiceHost:   u.Host,
-			AssistedServiceScheme: u.Scheme,
-		}
-		server = httptest.NewServer(handler)
-		client = server.Client()
+		Context("with no auth", func() {
+			var (
+				server *httptest.Server
+				client *http.Client
+			)
 
-		fullImageFile, err := os.CreateTemp("", "image_handler_test")
-		Expect(err).NotTo(HaveOccurred())
-		_, err = fullImageFile.Write([]byte("someisocontent"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fullImageFile.Sync()).To(Succeed())
-		Expect(fullImageFile.Close()).To(Succeed())
-		fullImageFilename = fullImageFile.Name()
+			BeforeEach(func() {
+				assistedServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/assisted-install/v1/clusters/%s/downloads/files", imageID), "file_name=discovery.ign"),
+						ghttp.RespondWith(http.StatusOK, ignitionContent),
+					),
+				)
 
-		minImageFile, err := os.CreateTemp("", "image_handler_test")
-		Expect(err).NotTo(HaveOccurred())
-		_, err = minImageFile.Write([]byte("minimalisocontent"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(minImageFile.Sync()).To(Succeed())
-		Expect(minImageFile.Close()).To(Succeed())
-		minImageFilename = minImageFile.Name()
-	})
+				u, err := url.Parse(assistedServer.URL())
+				Expect(err).NotTo(HaveOccurred())
 
-	AfterEach(func() {
-		server.Close()
-		assistedServer.Close()
-		os.Remove(fullImageFilename)
-		os.Remove(minImageFilename)
-	})
+				mockImageStream := func(isoPath string, ignitionBytes []byte) (io.ReadSeeker, error) {
+					defer GinkgoRecover()
+					Expect(ignitionBytes).To(Equal(ignitionArchiveBytes))
+					return os.Open(isoPath)
+				}
 
-	mockImage := func(version, imageType string) {
-		mockImageStore.EXPECT().HaveVersion(version).Return(true).AnyTimes()
+				handler := &ImageHandler{
+					ImageStore:            mockImageStore,
+					GenerateImageStream:   mockImageStream,
+					AssistedServiceHost:   u.Host,
+					AssistedServiceScheme: u.Scheme,
+				}
+				server = httptest.NewServer(handler)
+				client = server.Client()
+			})
 
-		var imageFile string
-		switch imageType {
-		case imagestore.ImageTypeFull:
-			imageFile = fullImageFilename
-		case imagestore.ImageTypeMinimal:
-			imageFile = minImageFilename
-		default:
-			Fail("cannot mock with an unsupported image type")
-		}
-		mockImageStore.EXPECT().BaseFile(version, imageType).Return(imageFile, nil).AnyTimes()
-	}
+			AfterEach(func() {
+				server.Close()
+			})
 
-	expectSuccessfulResponse := func(resp *http.Response, content []byte) {
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		respContent, err := io.ReadAll(resp.Body)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(respContent).To(Equal(content))
-	}
+			It("returns a full image", func() {
+				mockImage("4.8", imagestore.ImageTypeFull)
+				path := fmt.Sprintf("/images/%s?version=4.8&type=full", imageID)
+				resp, err := client.Get(server.URL + path)
+				Expect(err).NotTo(HaveOccurred())
+				expectSuccessfulResponse(resp, []byte("someisocontent"))
+			})
 
-	It("returns a full image", func() {
-		mockImage("4.8", imagestore.ImageTypeFull)
-		path := fmt.Sprintf("/images/%s?version=4.8&type=full", imageID)
-		resp, err := client.Get(server.URL + path)
-		Expect(err).NotTo(HaveOccurred())
-		expectSuccessfulResponse(resp, []byte("someisocontent"))
-	})
+			It("returns a minimal image", func() {
+				mockImage("4.8", imagestore.ImageTypeMinimal)
+				path := fmt.Sprintf("/images/%s?version=4.8&type=minimal", imageID)
+				resp, err := client.Get(server.URL + path)
+				Expect(err).NotTo(HaveOccurred())
+				expectSuccessfulResponse(resp, []byte("minimalisocontent"))
+			})
 
-	It("returns a minimal image", func() {
-		mockImage("4.8", imagestore.ImageTypeMinimal)
-		path := fmt.Sprintf("/images/%s?version=4.8&type=minimal", imageID)
-		resp, err := client.Get(server.URL + path)
-		Expect(err).NotTo(HaveOccurred())
-		expectSuccessfulResponse(resp, []byte("minimalisocontent"))
-	})
+			It("fails for a non-existant version", func() {
+				mockImageStore.EXPECT().HaveVersion("4.7").Return(false)
+				path := fmt.Sprintf("/images/%s?version=4.7&type=full", imageID)
+				resp, err := client.Get(server.URL + path)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+			})
 
-	It("fails for a non-existant version", func() {
-		mockImageStore.EXPECT().HaveVersion("4.7").Return(false)
-		path := fmt.Sprintf("/images/%s?version=4.7&type=full", imageID)
-		resp, err := client.Get(server.URL + path)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
-	})
+			It("fails when no version is supplied", func() {
+				path := fmt.Sprintf("/images/%s?type=full", imageID)
+				resp, err := client.Get(server.URL + path)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+			})
 
-	It("fails when no version is supplied", func() {
-		path := fmt.Sprintf("/images/%s?type=full", imageID)
-		resp, err := client.Get(server.URL + path)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
-	})
+			It("fails when no type is supplied", func() {
+				mockImageStore.EXPECT().HaveVersion("4.8").Return(true)
+				path := fmt.Sprintf("/images/%s?version=4.8", imageID)
+				resp, err := client.Get(server.URL + path)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+			})
 
-	It("fails when no type is supplied", func() {
-		mockImageStore.EXPECT().HaveVersion("4.8").Return(true)
-		path := fmt.Sprintf("/images/%s?version=4.8", imageID)
-		resp, err := client.Get(server.URL + path)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
-	})
+			It("fails when no image id is supplied", func() {
+				resp, err := client.Get(server.URL + "/images/")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			})
+		})
 
-	It("fails when no image id is supplied", func() {
-		resp, err := client.Get(server.URL + "/images/")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		It("passes the token in a header with header auth", func() {
+			assistedServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/api/assisted-install/v1/clusters/%s/downloads/files", imageID), "file_name=discovery.ign"),
+					ghttp.VerifyHeader(http.Header{"Authorization": []string{"Bearer mytoken"}}),
+					ghttp.RespondWith(http.StatusOK, ignitionContent),
+				),
+			)
+
+			u, err := url.Parse(assistedServer.URL())
+			Expect(err).NotTo(HaveOccurred())
+
+			mockImageStream := func(isoPath string, ignitionBytes []byte) (io.ReadSeeker, error) {
+				defer GinkgoRecover()
+				Expect(ignitionBytes).To(Equal(ignitionArchiveBytes))
+				return os.Open(isoPath)
+			}
+
+			handler := &ImageHandler{
+				ImageStore:            mockImageStore,
+				GenerateImageStream:   mockImageStream,
+				AssistedServiceHost:   u.Host,
+				AssistedServiceScheme: u.Scheme,
+				RequestAuthType:       RequestAuthTypeHeader,
+			}
+			server := httptest.NewServer(handler)
+			defer server.Close()
+
+			mockImage("4.8", imagestore.ImageTypeFull)
+			path := fmt.Sprintf("/images/%s?version=4.8&type=full&api_key=mytoken", imageID)
+			resp, err := server.Client().Get(server.URL + path)
+			Expect(err).NotTo(HaveOccurred())
+			expectSuccessfulResponse(resp, []byte("someisocontent"))
+		})
+
+		It("passes the token in a param with param auth", func() {
+			assistedPath := fmt.Sprintf("/api/assisted-install/v1/clusters/%s/downloads/files", imageID)
+			assistedServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", assistedPath, "file_name=discovery.ign&api_key=mytoken"),
+					ghttp.RespondWith(http.StatusOK, ignitionContent),
+				),
+			)
+
+			u, err := url.Parse(assistedServer.URL())
+			Expect(err).NotTo(HaveOccurred())
+
+			mockImageStream := func(isoPath string, ignitionBytes []byte) (io.ReadSeeker, error) {
+				defer GinkgoRecover()
+				Expect(ignitionBytes).To(Equal(ignitionArchiveBytes))
+				return os.Open(isoPath)
+			}
+
+			handler := &ImageHandler{
+				ImageStore:            mockImageStore,
+				GenerateImageStream:   mockImageStream,
+				AssistedServiceHost:   u.Host,
+				AssistedServiceScheme: u.Scheme,
+				RequestAuthType:       RequestAuthTypeParam,
+			}
+			server := httptest.NewServer(handler)
+			defer server.Close()
+
+			mockImage("4.8", imagestore.ImageTypeFull)
+			path := fmt.Sprintf("/images/%s?version=4.8&type=full&api_key=mytoken", imageID)
+			resp, err := server.Client().Get(server.URL + path)
+			Expect(err).NotTo(HaveOccurred())
+			expectSuccessfulResponse(resp, []byte("someisocontent"))
+		})
 	})
 })
 

--- a/main.go
+++ b/main.go
@@ -16,10 +16,11 @@ import (
 var Options struct {
 	AssistedServiceScheme string `envconfig:"ASSISTED_SERVICE_SCHEME"`
 	AssistedServiceHost   string `envconfig:"ASSISTED_SERVICE_HOST"`
-	Port                  string `envconfig:"PORT" default:"8080"`
+	DataDir               string `envconfig:"DATA_DIR"`
 	HTTPSKeyFile          string `envconfig:"HTTPS_KEY_FILE"`
 	HTTPSCertFile         string `envconfig:"HTTPS_CERT_FILE"`
-	DataDir               string `envconfig:"DATA_DIR"`
+	Port                  string `envconfig:"PORT" default:"8080"`
+	RequestAuthType       string `envconfig:"REQUEST_AUTH_TYPE"`
 }
 
 func main() {
@@ -38,7 +39,7 @@ func main() {
 		log.Fatalf("Failed to populate image store: %v\n", err)
 	}
 
-	http.Handle("/images/", handlers.NewImageHandler(is, Options.AssistedServiceScheme, Options.AssistedServiceHost))
+	http.Handle("/images/", handlers.NewImageHandler(is, Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.RequestAuthType))
 	http.Handle("/health", handlers.NewHealthHandler())
 	http.Handle("/metrics", promhttp.Handler())
 


### PR DESCRIPTION
We will either pass this token in another query parameter or as a header
depending on the value of the `REQUEST_AUTH_TYPE` env var.

https://issues.redhat.com/browse/MGMT-7499