### PR TITLE
Add build_deploy.sh script to create app-sre image

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -exu
+
+TAG=$(git rev-parse --short=7 HEAD)
+REPO="quay.io/app-sre/assisted-image-service"
+export IMAGE="${REPO}:${TAG}"
+
+make build
+
+podman login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
+
+podman tag "${IMAGE}" "${REPO}:latest"
+podman push "${IMAGE}"
+podman push "${REPO}:latest"


### PR DESCRIPTION
Adds a build file similar to the [one in assisted-service](https://github.com/openshift/assisted-service/blob/165e849305ecb67cc6b1b24ccb76137c10693f53/build_deploy.sh)

https://issues.redhat.com/browse/MGMT-7255