### PR TITLE
Use docker for build script instead of podman

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,12 +4,12 @@ set -exu
 
 TAG=$(git rev-parse --short=7 HEAD)
 REPO="quay.io/app-sre/assisted-image-service"
-export IMAGE="${REPO}:${TAG}"
+IMAGE="${REPO}:${TAG}"
 
-make build
+docker build -f Dockerfile.image-service . -t ${IMAGE}
 
-podman login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
+docker login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
 
-podman tag "${IMAGE}" "${REPO}:latest"
-podman push "${IMAGE}"
-podman push "${REPO}:latest"
+docker tag "${IMAGE}" "${REPO}:latest"
+docker push "${IMAGE}"
+docker push "${REPO}:latest"


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->
It looks like the app-sre automation we're using for building the image doesn't have an option to use podman. So just change the script to use docker and see if that works.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
N/A

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @djzager 
/cc @omertuc 

## Links
<!--
List any applicable links to related PRs or issues
-->

Logs from previous job:
```
11:30:41 [openshift-assisted-image-service-gh-build-main] $ /bin/sh -xe /tmp/jenkins2921027276091833060.sh
11:30:41 + ./build_deploy.sh
11:30:41 ++ git rev-parse --short=7 HEAD
11:30:41 + TAG=1f34613
11:30:41 + REPO=quay.io/app-sre/assisted-image-service
11:30:41 + export IMAGE=quay.io/app-sre/assisted-image-service:1f34613
11:30:41 + IMAGE=quay.io/app-sre/assisted-image-service:1f34613
11:30:41 + make build
11:30:41 podman build -f Dockerfile.image-service . -t quay.io/app-sre/assisted-image-service:1f34613
11:30:41 make: podman: Command not found
11:30:41 make: *** [build] Error 127
11:30:41 Build step 'Execute shell' marked build as failure
```

## Checklist

- [x] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
