### PR TITLE
Use array format for versions and add image arch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,26 @@ skipper make test
 
 Example `RHCOS_VERSIONS`:
 ```json
-{
-	"4.6": {
-		"iso_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso",
-		"rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img"
-	},
-	"4.7": {
-		"iso_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.13/rhcos-4.7.13-x86_64-live.x86_64.iso",
-		"rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.13/rhcos-live-rootfs.x86_64.img"
-	},
-	"4.8": {
-		"iso_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.8.0-rc.3/rhcos-4.8.0-rc.3-x86_64-live.x86_64.iso",
-		"rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.8.0-rc.3/rhcos-live-rootfs.x86_64.img"
-	}
-}
+[
+    {
+        "openshift_version": "4.6",
+        "cpu_architecture": "x86_64",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso",
+        "rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img",
+    },
+    {
+        "openshift_version": "4.7",
+        "cpu_architecture": "x86_64",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.13/rhcos-4.7.13-x86_64-live.x86_64.iso",
+        "rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.13/rhcos-live-rootfs.x86_64.img",
+    },
+    {
+        "openshift_version": "4.8",
+        "cpu_architecture": "x86_64",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-4.8.2-x86_64-live.x86_64.iso",
+        "rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-live-rootfs.x86_64.img",
+    }
+]
 ```
 
 ## API

--- a/internal/handlers/images.go
+++ b/internal/handlers/images.go
@@ -124,11 +124,6 @@ func (h *ImageHandler) parseQueryParams(values url.Values) (string, string, stri
 }
 
 func (h *ImageHandler) imageStreamForID(imageID, version, imageType, apiKey string) (io.ReadSeeker, error) {
-	f, err := h.ImageStore.BaseFile(version, imageType)
-	if err != nil {
-		return nil, err
-	}
-
 	ignition, err := h.ignitionContent(imageID, apiKey)
 	if err != nil {
 		return nil, err
@@ -142,7 +137,7 @@ func (h *ImageHandler) imageStreamForID(imageID, version, imageType, apiKey stri
 		}
 	}
 
-	return h.GenerateImageStream(f, ignition, ramdisk)
+	return h.GenerateImageStream(h.ImageStore.PathForParams(imageType, version, "x86_64"), ignition, ramdisk)
 }
 
 func (h *ImageHandler) ramdiskContent(imageID, apiKey string) ([]byte, error) {

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -76,7 +76,7 @@ var _ = Describe("ServeHTTP", func() {
 			default:
 				Fail("cannot mock with an unsupported image type")
 			}
-			mockImageStore.EXPECT().BaseFile(version, imageType).Return(imageFile, nil).AnyTimes()
+			mockImageStore.EXPECT().PathForParams(imageType, version, "x86_64").Return(imageFile).AnyTimes()
 		}
 
 		expectSuccessfulResponse := func(resp *http.Response, content []byte) {

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 )
 
@@ -41,7 +41,7 @@ var _ = Context("with a data directory configured", func() {
 
 		Context("with RHCOS_VERSIONS set", func() {
 			var (
-				versions = `{"4.8": {"iso_url": "http://example.com/image/48.iso", "rootfs_url": "http://example.com/image/48.img"}}`
+				versions = `[{"openshift_version": "4.8", "cpu_architecture": "x86_64", "url": "http://example.com/image/48.iso", "rootfs_url": "http://example.com/image/48.img"}]`
 			)
 
 			BeforeEach(func() {
@@ -55,10 +55,12 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(nil, dataDir)
 				Expect(err).NotTo(HaveOccurred())
 
-				expected := map[string]map[string]string{
-					"4.8": {
-						"iso_url":    "http://example.com/image/48.iso",
-						"rootfs_url": "http://example.com/image/48.img",
+				expected := []map[string]string{
+					{
+						"openshift_version": "4.8",
+						"cpu_architecture":  "x86_64",
+						"url":               "http://example.com/image/48.iso",
+						"rootfs_url":        "http://example.com/image/48.img",
 					},
 				}
 				Expect(is.(*rhcosStore).versions).To(Equal(expected))
@@ -68,23 +70,12 @@ var _ = Context("with a data directory configured", func() {
 
 	Context("with a test server", func() {
 		var (
-			ts  *httptest.Server
+			ts  *ghttp.Server
 			ctx = context.Background()
 		)
 
 		BeforeEach(func() {
-			ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch p := r.URL.Path; p {
-				case "/some.iso":
-					_, err := w.Write([]byte("someisocontenthere"))
-					Expect(err).NotTo(HaveOccurred())
-				case "/fail.iso":
-					w.WriteHeader(http.StatusInternalServerError)
-				case "/dontcallthis.iso":
-					Fail("endpoint should not be queried")
-				}
-
-			}))
+			ts = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
@@ -94,16 +85,24 @@ var _ = Context("with a data directory configured", func() {
 
 		Describe("Populate", func() {
 			var (
-				ctrl       *gomock.Controller
-				mockEditor *isoeditor.MockEditor
+				ctrl             *gomock.Controller
+				mockEditor       *isoeditor.MockEditor
+				versionsTemplate = `[{"openshift_version": "4.8", "cpu_architecture": "x86_64", "url": "%s", "rootfs_url": "http://example.com/image/48.img"}]`
 			)
+
 			BeforeEach(func() {
 				ctrl = gomock.NewController(GinkgoT())
 				mockEditor = isoeditor.NewMockEditor(ctrl)
 			})
 
 			It("downloads an image correctly", func() {
-				versions := fmt.Sprintf(`{"4.8": {"iso_url": "%s", "rootfs_url": "http://example.com/image/48.img"}}`, ts.URL+"/some.iso")
+				ts.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/some.iso"),
+						ghttp.RespondWith(http.StatusOK, "someisocontenthere"),
+					),
+				)
+				versions := fmt.Sprintf(versionsTemplate, ts.URL()+"/some.iso")
 				Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
 				is, err := NewImageStore(mockEditor, dataDir)
@@ -112,13 +111,19 @@ var _ = Context("with a data directory configured", func() {
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "http://example.com/image/48.img", gomock.Any()).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
-				content, err := os.ReadFile(filepath.Join(dataDir, "some.iso"))
+				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-4.8-x86_64.iso"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(content)).To(Equal("someisocontenthere"))
 			})
 
 			It("fails when the download fails", func() {
-				versions := fmt.Sprintf(`{"4.8": {"iso_url": "%s", "rootfs_url": "http://example.com/image/48.img"}}`, ts.URL+"/fail.iso")
+				ts.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/fail.iso"),
+						ghttp.RespondWith(http.StatusInternalServerError, "server error"),
+					),
+				)
+				versions := fmt.Sprintf(versionsTemplate, ts.URL()+"/fail.iso")
 				Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
 				is, err := NewImageStore(mockEditor, dataDir)
@@ -127,7 +132,13 @@ var _ = Context("with a data directory configured", func() {
 			})
 
 			It("fails when minimal iso creation fails", func() {
-				versions := fmt.Sprintf(`{"4.8": {"iso_url": "%s", "rootfs_url": "http://example.com/image/48.img"}}`, ts.URL+"/some.iso")
+				ts.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/some.iso"),
+						ghttp.RespondWith(http.StatusOK, "someisocontenthere"),
+					),
+				)
+				versions := fmt.Sprintf(versionsTemplate, ts.URL()+"/some.iso")
 				Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
 				is, err := NewImageStore(mockEditor, dataDir)
@@ -138,77 +149,48 @@ var _ = Context("with a data directory configured", func() {
 			})
 
 			It("doesn't download if the file already exists", func() {
-				versions := fmt.Sprintf(`{"4.8": {"iso_url": "%s", "rootfs_url": "http://example.com/image/48.img"}}`, ts.URL+"/dontcallthis.iso")
+				ts.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/dontcallthis.iso"),
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { Fail("endpoint should not be queried") }),
+					),
+				)
+				versions := fmt.Sprintf(versionsTemplate, ts.URL()+"/dontcallthis.iso")
 				Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
 				is, err := NewImageStore(mockEditor, dataDir)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(os.WriteFile(filepath.Join(dataDir, "dontcallthis.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-4.8-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
 
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "http://example.com/image/48.img", gomock.Any()).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 			})
 
 			It("doesn't create the minimal iso when it's already present", func() {
-				versions := fmt.Sprintf(`{"4.8": {"iso_url": "%s", "rootfs_url": "http://example.com/image/48.img"}}`, ts.URL+"/dontcallthis.iso")
+				ts.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/dontcallthis.iso"),
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { Fail("endpoint should not be queried") }),
+					),
+				)
+				versions := fmt.Sprintf(versionsTemplate, ts.URL()+"/dontcallthis.iso")
 				Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
 				is, err := NewImageStore(mockEditor, dataDir)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(os.WriteFile(filepath.Join(dataDir, "dontcallthis.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
-				Expect(os.WriteFile(filepath.Join(dataDir, "minimal-dontcallthis.iso"), []byte("minimalisocontent"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-4.8-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-minimal-4.8-x86_64.iso"), []byte("minimalisocontent"), 0600)).To(Succeed())
 
 				Expect(is.Populate(ctx)).To(Succeed())
 			})
 		})
 
-		Describe("BaseFile", func() {
-			var (
-				is         ImageStore
-				ctrl       *gomock.Controller
-				mockEditor *isoeditor.MockEditor
-			)
-
-			BeforeEach(func() {
-				versions := fmt.Sprintf(`{"4.8": {"iso_url": "%s", "rootfs_url": "http://example.com/image/48.img"}}`, ts.URL+"/some.iso")
-				Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
-				ctrl = gomock.NewController(GinkgoT())
-				mockEditor = isoeditor.NewMockEditor(ctrl)
-
-				var err error
-				is, err = NewImageStore(mockEditor, dataDir)
+		Describe("PathForParams", func() {
+			It("creates the correct path", func() {
+				is, err := NewImageStore(nil, dataDir)
 				Expect(err).NotTo(HaveOccurred())
-
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "http://example.com/image/48.img", gomock.Any()).Return(nil)
-				Expect(os.WriteFile(filepath.Join(dataDir, "minimal-some.iso"), []byte("minimalisocontent"), 0600)).To(Succeed())
-
-				Expect(is.Populate(ctx)).To(Succeed())
-			})
-
-			It("returns the correct file for full iso", func() {
-				f, err := is.BaseFile("4.8", ImageTypeFull)
-				Expect(err).NotTo(HaveOccurred())
-				content, err := os.ReadFile(f)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(content)).To(Equal("someisocontenthere"))
-			})
-
-			It("returns the correct file for minimal iso", func() {
-				f, err := is.BaseFile("4.8", ImageTypeMinimal)
-				Expect(err).NotTo(HaveOccurred())
-				content, err := os.ReadFile(f)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(content)).To(Equal("minimalisocontent"))
-			})
-
-			It("fails for a missing version", func() {
-				_, err := is.BaseFile("3.2", ImageTypeFull)
-				Expect(err).To(HaveOccurred())
-			})
-
-			It("fails for an unsupported image type", func() {
-				_, err := is.BaseFile("4.8", "something")
-				Expect(err).To(HaveOccurred())
+				expected := filepath.Join(dataDir, "rhcos-type-version-arch.iso")
+				Expect(is.PathForParams("type", "version", "arch")).To(Equal(expected))
 			})
 		})
 	})

--- a/pkg/imagestore/mock_imagestore.go
+++ b/pkg/imagestore/mock_imagestore.go
@@ -34,21 +34,6 @@ func (m *MockImageStore) EXPECT() *MockImageStoreMockRecorder {
 	return m.recorder
 }
 
-// BaseFile mocks base method.
-func (m *MockImageStore) BaseFile(arg0, arg1 string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BaseFile", arg0, arg1)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BaseFile indicates an expected call of BaseFile.
-func (mr *MockImageStoreMockRecorder) BaseFile(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BaseFile", reflect.TypeOf((*MockImageStore)(nil).BaseFile), arg0, arg1)
-}
-
 // HaveVersion mocks base method.
 func (m *MockImageStore) HaveVersion(arg0 string) bool {
 	m.ctrl.T.Helper()
@@ -61,6 +46,20 @@ func (m *MockImageStore) HaveVersion(arg0 string) bool {
 func (mr *MockImageStoreMockRecorder) HaveVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HaveVersion", reflect.TypeOf((*MockImageStore)(nil).HaveVersion), arg0)
+}
+
+// PathForParams mocks base method.
+func (m *MockImageStore) PathForParams(arg0, arg1, arg2 string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PathForParams", arg0, arg1, arg2)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// PathForParams indicates an expected call of PathForParams.
+func (mr *MockImageStoreMockRecorder) PathForParams(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PathForParams", reflect.TypeOf((*MockImageStore)(nil).PathForParams), arg0, arg1, arg2)
 }
 
 // Populate mocks base method.


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

This commit moves us from the map versions format inspired by the old
assisted-service `OPENSHIFT_VERSIONS` map to the new format for
`RHCOS_VERSIONS`. The main difference is using an array instead of a
map.

This also adds a cpu_architecture field to each default version entry.

A follow-up PR will add a parameter to the API to specify architecture.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

Ran the service locally and tested generating both full and minimal isos for an infra-env in integration.
Both images registered successfully.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @danielerez 
/cc @djzager 

## Links
<!--
List any applicable links to related PRs or issues
-->

Related assisted-service PRs:
https://github.com/openshift/assisted-service/pull/2369
https://github.com/openshift/assisted-service/pull/2454

JIRA:
https://issues.redhat.com/browse/MGMT-7453

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] ~~This change does not require a documentation update (docstring, `docs`, README, etc)~~ Updated README.md
- [x] Does this change include unit tests (note that code changes require unit tests)
