### PR TITLE
feat: support self-signed certificates on assisted-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,19 @@ Example `RHCOS_VERSIONS`:
         "openshift_version": "4.6",
         "cpu_architecture": "x86_64",
         "url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso",
-        "rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img",
+        "rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img"
     },
     {
         "openshift_version": "4.7",
         "cpu_architecture": "x86_64",
         "url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.13/rhcos-4.7.13-x86_64-live.x86_64.iso",
-        "rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.13/rhcos-live-rootfs.x86_64.img",
+        "rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.13/rhcos-live-rootfs.x86_64.img"
     },
     {
         "openshift_version": "4.8",
         "cpu_architecture": "x86_64",
         "url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-4.8.2-x86_64-live.x86_64.iso",
-        "rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-live-rootfs.x86_64.img",
+        "rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-live-rootfs.x86_64.img"
     }
 ]
 ```

--- a/internal/handlers/images.go
+++ b/internal/handlers/images.go
@@ -74,7 +74,8 @@ func NewImageHandler(is imagestore.ImageStore, assistedServiceScheme, assistedSe
 
 		t := &http.Transport{
 			TLSClientConfig: &tls.Config{
-				RootCAs: caCertPool,
+				RootCAs:    caCertPool,
+				MinVersion: tls.VersionTLS12,
 			},
 		}
 		client.Transport = t

--- a/internal/handlers/images.go
+++ b/internal/handlers/images.go
@@ -63,14 +63,16 @@ func NewImageHandler(is imagestore.ImageStore, assistedServiceScheme, assistedSe
 		Recorder: metrics.NewRecorder(metricsConfig),
 	})
 
-	client := http.DefaultClient
+	client := &http.Client{}
 	if caCertFile != "" {
 		caCert, err := ioutil.ReadFile(caCertFile)
 		if err != nil {
 			log.Fatalf("Error opening cert file %s, %s", caCertFile, err)
 		}
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			log.Fatalf("Failed to append cert %s, %s", caCertFile, err)
+		}
 
 		t := &http.Transport{
 			TLSClientConfig: &tls.Config{

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -119,6 +119,7 @@ var _ = Describe("ServeHTTP", func() {
 					GenerateImageStream:   mockImageStream,
 					AssistedServiceHost:   u.Host,
 					AssistedServiceScheme: u.Scheme,
+					Client:                http.DefaultClient,
 				}
 				server = httptest.NewServer(handler)
 				client = server.Client()
@@ -219,6 +220,7 @@ var _ = Describe("ServeHTTP", func() {
 				AssistedServiceHost:   u.Host,
 				AssistedServiceScheme: u.Scheme,
 				RequestAuthType:       RequestAuthTypeHeader,
+				Client:                http.DefaultClient,
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()
@@ -254,6 +256,7 @@ var _ = Describe("ServeHTTP", func() {
 				AssistedServiceHost:   u.Host,
 				AssistedServiceScheme: u.Scheme,
 				RequestAuthType:       RequestAuthTypeParam,
+				Client:                http.DefaultClient,
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var Options struct {
 	DataDir               string `envconfig:"DATA_DIR"`
 	HTTPSKeyFile          string `envconfig:"HTTPS_KEY_FILE"`
 	HTTPSCertFile         string `envconfig:"HTTPS_CERT_FILE"`
+	HTTPSCAFile           string `envconfig:"HTTPS_CA_FILE"`
 	ListenPort            string `envconfig:"LISTEN_PORT" default:"8080"`
 	RequestAuthType       string `envconfig:"REQUEST_AUTH_TYPE"`
 }
@@ -39,7 +40,7 @@ func main() {
 		log.Fatalf("Failed to populate image store: %v\n", err)
 	}
 
-	http.Handle("/images/", handlers.NewImageHandler(is, Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.RequestAuthType))
+	http.Handle("/images/", handlers.NewImageHandler(is, Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.RequestAuthType, Options.HTTPSCAFile))
 	http.Handle("/health", handlers.NewHealthHandler())
 	http.Handle("/metrics", promhttp.Handler())
 


### PR DESCRIPTION
## Description

The assisted-service may likely be using self-signed certificates. This
change makes it possible to start the imagehandler with a cabundle to
make trust between the image-service and assisted-service possible.

Additionally, we break up the handling of `err != nil` to ensure we
don't panic because response != 2xx but err was nil.


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
dev-scripts environment


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @

## Links
https://github.com/openshift/assisted-service/pull/2480


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
