### PR TITLE
MGMT-7754: Support iso creation with EFI boot only

### DIFF
--- a/pkg/isoeditor/isoeditor_suite_test.go
+++ b/pkg/isoeditor/isoeditor_suite_test.go
@@ -51,6 +51,9 @@ func createTestFiles(volumeID string) (string, string) {
 	f, err := os.Create(filepath.Join(filesDir, "images", "efiboot.img"))
 	Expect(err).ToNot(HaveOccurred())
 	Expect(f.Truncate(8184422)).To(Succeed())
+	f, err = os.Create(filepath.Join(filesDir, "isolinux", "isolinux.bin"))
+	Expect(err).ToNot(HaveOccurred())
+	Expect(f.Truncate(64)).To(Succeed())
 
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/assisted_installer_custom.img"), make([]byte, RamDiskPaddingLength), 0600)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/ignition.img"), make([]byte, ignitionPaddingLength), 0600)).To(Succeed())

--- a/pkg/isoeditor/isoutil.go
+++ b/pkg/isoeditor/isoutil.go
@@ -146,6 +146,27 @@ func Create(outPath string, workDir string, volumeLabel string) error {
 				},
 			},
 		}
+	} else if exists, _ := fileExists(filepath.Join(workDir, "images/efiboot.img")); exists {
+		// Creating an ISO with EFI boot only
+		efiSectors, err := efiLoadSectors(workDir)
+		if err != nil {
+			return err
+		}
+		if exists, _ := fileExists(filepath.Join(workDir, "boot.catalog")); !exists {
+			return fmt.Errorf("missing boot.catalog file")
+		}
+		options.ElTorito = &iso9660.ElTorito{
+			BootCatalog:     "boot.catalog",
+			HideBootCatalog: true,
+			Entries: []*iso9660.ElToritoEntry{
+				{
+					Platform:  iso9660.EFI,
+					Emulation: iso9660.NoEmulation,
+					BootFile:  "images/efiboot.img",
+					LoadSize:  efiSectors,
+				},
+			},
+		}
 	}
 
 	return iso.Finalize(options)


### PR DESCRIPTION
## Description
As the aarch64 rhcos image[*] contains a single boot image (efiboot.img),
added proper support to isoutil for creating an ISO with only that boot platform.
This should facilitate the creation of a minimal ISO template for arm64 CPU architecture.

Note: same as done in assisted-service - https://github.com/openshift/assisted-service/pull/2563

[*] https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/4.9.0-fc.1/rhcos-4.9.0-fc.1-aarch64-live.aarch64.iso

## How was this code tested?
Tested same change in assisted-service.

## Assignees
/cc @carbonin 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
