### PR TITLE
Align type values with those from assisted-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Downloads the RHCOS image for the specified image ID.
 
 `version`: indicates the version of the RHCOS base image to use (must match an entry in `RHCOS_VERSIONS`)
 `arch`: the base image cpu architecture (must match an entry in `RHCOS_VERSIONS`)
-`type`: `full` to download the ISO including the rootfs, `minimal` to download the iso without the rootfs
+`type`: `full-iso` to download the ISO including the rootfs, `minimal-iso` to download the iso without the rootfs
 `api_key`: the api token to pass through to the assisted service calls if authentication is required
 
 ### `GET /health`

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -131,7 +131,7 @@ var _ = Describe("ServeHTTP", func() {
 
 			It("returns a full image", func() {
 				mockImage("4.8", imagestore.ImageTypeFull, defaultArch)
-				path := fmt.Sprintf("/images/%s?version=4.8&type=full", imageID)
+				path := fmt.Sprintf("/images/%s?version=4.8&type=full-iso", imageID)
 				resp, err := client.Get(server.URL + path)
 				Expect(err).NotTo(HaveOccurred())
 				expectSuccessfulResponse(resp, []byte("someisocontent"))
@@ -139,7 +139,7 @@ var _ = Describe("ServeHTTP", func() {
 
 			It("uses the arch parameter", func() {
 				mockImage("4.8", imagestore.ImageTypeFull, "arm64")
-				path := fmt.Sprintf("/images/%s?version=4.8&type=full&arch=arm64", imageID)
+				path := fmt.Sprintf("/images/%s?version=4.8&type=full-iso&arch=arm64", imageID)
 				resp, err := client.Get(server.URL + path)
 				Expect(err).NotTo(HaveOccurred())
 				expectSuccessfulResponse(resp, []byte("someisocontent"))
@@ -154,7 +154,7 @@ var _ = Describe("ServeHTTP", func() {
 					),
 				)
 				mockImage("4.8", imagestore.ImageTypeMinimal, defaultArch)
-				path := fmt.Sprintf("/images/%s?version=4.8&type=minimal", imageID)
+				path := fmt.Sprintf("/images/%s?version=4.8&type=minimal-iso", imageID)
 				resp, err := client.Get(server.URL + path)
 				Expect(err).NotTo(HaveOccurred())
 				expectSuccessfulResponse(resp, []byte("minimalisocontent"))
@@ -168,7 +168,7 @@ var _ = Describe("ServeHTTP", func() {
 					),
 				)
 				mockImage("4.8", imagestore.ImageTypeMinimal, defaultArch)
-				path := fmt.Sprintf("/images/%s?version=4.8&type=minimal", imageID)
+				path := fmt.Sprintf("/images/%s?version=4.8&type=minimal-iso", imageID)
 				resp, err := client.Get(server.URL + path)
 				Expect(err).NotTo(HaveOccurred())
 				expectSuccessfulResponse(resp, []byte("minimalisocontent"))
@@ -176,14 +176,14 @@ var _ = Describe("ServeHTTP", func() {
 
 			It("fails for a non-existant version", func() {
 				mockImageStore.EXPECT().HaveVersion("4.7", defaultArch).Return(false)
-				path := fmt.Sprintf("/images/%s?version=4.7&type=full", imageID)
+				path := fmt.Sprintf("/images/%s?version=4.7&type=full-iso", imageID)
 				resp, err := client.Get(server.URL + path)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 			})
 
 			It("fails when no version is supplied", func() {
-				path := fmt.Sprintf("/images/%s?type=full", imageID)
+				path := fmt.Sprintf("/images/%s?type=full-iso", imageID)
 				resp, err := client.Get(server.URL + path)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -234,7 +234,7 @@ var _ = Describe("ServeHTTP", func() {
 			defer server.Close()
 
 			mockImage("4.8", imagestore.ImageTypeFull, defaultArch)
-			path := fmt.Sprintf("/images/%s?version=4.8&type=full&api_key=mytoken", imageID)
+			path := fmt.Sprintf("/images/%s?version=4.8&type=full-iso&api_key=mytoken", imageID)
 			resp, err := server.Client().Get(server.URL + path)
 			Expect(err).NotTo(HaveOccurred())
 			expectSuccessfulResponse(resp, []byte("someisocontent"))
@@ -270,7 +270,7 @@ var _ = Describe("ServeHTTP", func() {
 			defer server.Close()
 
 			mockImage("4.8", imagestore.ImageTypeFull, defaultArch)
-			path := fmt.Sprintf("/images/%s?version=4.8&type=full&api_key=mytoken", imageID)
+			path := fmt.Sprintf("/images/%s?version=4.8&type=full-iso&api_key=mytoken", imageID)
 			resp, err := server.Client().Get(server.URL + path)
 			Expect(err).NotTo(HaveOccurred())
 			expectSuccessfulResponse(resp, []byte("someisocontent"))

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -55,8 +55,8 @@ type rhcosStore struct {
 }
 
 const (
-	ImageTypeFull    = "full"
-	ImageTypeMinimal = "minimal"
+	ImageTypeFull    = "full-iso"
+	ImageTypeMinimal = "minimal-iso"
 )
 
 func NewImageStore(ed isoeditor.Editor, dataDir string) (ImageStore, error) {

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -111,7 +111,7 @@ var _ = Context("with a data directory configured", func() {
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "http://example.com/image/48.img", gomock.Any()).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
-				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-4.8-x86_64.iso"))
+				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-x86_64.iso"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(content)).To(Equal("someisocontenthere"))
 			})
@@ -160,7 +160,7 @@ var _ = Context("with a data directory configured", func() {
 
 				is, err := NewImageStore(mockEditor, dataDir)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-4.8-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
 
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "http://example.com/image/48.img", gomock.Any()).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
@@ -178,8 +178,8 @@ var _ = Context("with a data directory configured", func() {
 
 				is, err := NewImageStore(mockEditor, dataDir)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-4.8-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
-				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-minimal-4.8-x86_64.iso"), []byte("minimalisocontent"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-minimal-iso-4.8-x86_64.iso"), []byte("minimalisocontent"), 0600)).To(Succeed())
 
 				Expect(is.Populate(ctx)).To(Succeed())
 			})


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

When constructing the download URL from assisted-service it will be
better to use the image type directly from that API rather than
translating it.

Specifically changes "full" to "full-iso" and "minimal" to "minimal-iso"

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

Unit tests cover this rather well.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @djzager 
/cc @flaper87 

## Links
<!--
List any applicable links to related PRs or issues
-->

Related to https://issues.redhat.com/browse/MGMT-7258

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
