### PR TITLE
MGMT-7762: Switch to stream8

### DIFF
--- a/Dockerfile.image-service
+++ b/Dockerfile.image-service
@@ -6,7 +6,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /assisted-image-service main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM quay.io/centos/centos:stream8
 
 ARG DATA_DIR=/data
 RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR


### PR DESCRIPTION
## Description
The original plan was to move all images to ubi8. This is not possible due to the lack
of some packages that are needed for other projects. We are now going to switch all images
to stream8 with the hope that the consistency accross repos will prevent (or help) with
debugging current/future issues in CI.

The goal is to keep component's builds as consistent as possible in the channels we are
releasing them on

Signed-off-by: Flavio Percoco <flavio@redhat.com>


## How was this code tested?
It wasn't! Relying on CI for this 

## Assignees

/cc @carbonin 
/cc @djzager 

## Links


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
