### PR TITLE
Limit requests in flight for image downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ skipper make test
 - `REQUEST_AUTH_TYPE` - determines how the auth token should be passed to the assisted service - either `header` or `param`
   - For `header` a header of the form `Authorization: Bearer <token>` is used
   - For `param` an `api_key=<token>` query parameter is added to the URL
+- `MAX_CONCURRENT_REQUESTS` - caps the number of inflight image downloads to avoid things like open file limits
 
 Example `RHCOS_VERSIONS`:
 ```json

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -120,6 +120,7 @@ var _ = Describe("ServeHTTP", func() {
 					AssistedServiceHost:   u.Host,
 					AssistedServiceScheme: u.Scheme,
 					Client:                http.DefaultClient,
+					sem:                   make(chan struct{}, 100),
 				}
 				server = httptest.NewServer(handler)
 				client = server.Client()
@@ -229,6 +230,7 @@ var _ = Describe("ServeHTTP", func() {
 				AssistedServiceScheme: u.Scheme,
 				RequestAuthType:       RequestAuthTypeHeader,
 				Client:                http.DefaultClient,
+				sem:                   make(chan struct{}, 100),
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()
@@ -265,6 +267,7 @@ var _ = Describe("ServeHTTP", func() {
 				AssistedServiceScheme: u.Scheme,
 				RequestAuthType:       RequestAuthTypeParam,
 				Client:                http.DefaultClient,
+				sem:                   make(chan struct{}, 100),
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var Options struct {
 	HTTPSCAFile           string `envconfig:"HTTPS_CA_FILE"`
 	ListenPort            string `envconfig:"LISTEN_PORT" default:"8080"`
 	RequestAuthType       string `envconfig:"REQUEST_AUTH_TYPE"`
+	MaxConcurrentRequests int    `envconfig:"MAX_CONCURRENT_REQUESTS" default:"400"`
 }
 
 func main() {
@@ -40,7 +41,7 @@ func main() {
 		log.Fatalf("Failed to populate image store: %v\n", err)
 	}
 
-	http.Handle("/images/", handlers.NewImageHandler(is, Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.RequestAuthType, Options.HTTPSCAFile))
+	http.Handle("/images/", handlers.NewImageHandler(is, Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.RequestAuthType, Options.HTTPSCAFile, Options.MaxConcurrentRequests))
 	http.Handle("/health", handlers.NewHealthHandler())
 	http.Handle("/metrics", promhttp.Handler())
 


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

When testing large numbers of simultaneous downloads (~1000)
some of the requests failed due to hitting an open file limit.

This commit adds an environment variable that allows us to cap the
number of downloads in progress.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

Ran the image service locally against a "no-op" assisted service that just returned some content immediately to any request.
I issued 1000 simultaneous requests to download images from the assisted service and ran into issues with local file limits like this:

`{"file":"/home/ncarboni/Source/assisted-image-service/internal/handlers/images.go:138","func":"github.com/openshift/assisted-image-service/internal/handlers.(*ImageHandler).ServeHTTP","level":"error","msg":"Error creating image stream: failed to create overwrite reader for ramdisk: Could not open device data/rhcos-minimal-iso-4.9-x86_64.iso with mode read-only: open data/rhcos-minimal-iso-4.9-x86_64.iso: too many open files\n","time":"2021-09-27T10:23:05-04:00"}`

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @djzager 

## Links
<!--
List any applicable links to related PRs or issues
-->

https://issues.redhat.com/browse/MGMT-7850

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] ~~This change does not require a documentation update (docstring, `docs`, README, etc)~~ README updated
- [ ] Does this change include unit tests (note that code changes require unit tests)
