### PR TITLE
Bug 2010819: Use the request context when making requests to assisted-service

### DIFF
--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	"github.com/openshift/assisted-image-service/pkg/imagestore"
+	"golang.org/x/sync/semaphore"
 )
 
 func TestHandlers(t *testing.T) {
@@ -120,7 +121,7 @@ var _ = Describe("ServeHTTP", func() {
 					AssistedServiceHost:   u.Host,
 					AssistedServiceScheme: u.Scheme,
 					Client:                http.DefaultClient,
-					sem:                   make(chan struct{}, 100),
+					sem:                   semaphore.NewWeighted(100),
 				}
 				server = httptest.NewServer(handler)
 				client = server.Client()
@@ -230,7 +231,7 @@ var _ = Describe("ServeHTTP", func() {
 				AssistedServiceScheme: u.Scheme,
 				RequestAuthType:       RequestAuthTypeHeader,
 				Client:                http.DefaultClient,
-				sem:                   make(chan struct{}, 100),
+				sem:                   semaphore.NewWeighted(100),
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()
@@ -267,7 +268,7 @@ var _ = Describe("ServeHTTP", func() {
 				AssistedServiceScheme: u.Scheme,
 				RequestAuthType:       RequestAuthTypeParam,
 				Client:                http.DefaultClient,
-				sem:                   make(chan struct{}, 100),
+				sem:                   semaphore.NewWeighted(100),
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ var Options struct {
 	HTTPSCAFile           string `envconfig:"HTTPS_CA_FILE"`
 	ListenPort            string `envconfig:"LISTEN_PORT" default:"8080"`
 	RequestAuthType       string `envconfig:"REQUEST_AUTH_TYPE"`
-	MaxConcurrentRequests int    `envconfig:"MAX_CONCURRENT_REQUESTS" default:"400"`
+	MaxConcurrentRequests int64  `envconfig:"MAX_CONCURRENT_REQUESTS" default:"400"`
 	RHCOSVersions         string `envconfig:"RHCOS_VERSIONS"`
 }
 


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->
After this change requests to assisted-service will be
canceled if/when the request to the image service is canceled.

This will ensure that requests that the client doesn't care about won't
run nmstatectl processes on assisted-service.

This also uses the `golang.org` semaphore package rather than a custom implementation.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

An image with this change was deployed to OpenShift alongside assisted service where I confirmed that canceling a download request on the client killed the running nmstatectl processes in the assisted service pod.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @djzager 

## Links
<!--
List any applicable links to related PRs or issues
-->

https://bugzilla.redhat.com/show_bug.cgi?id=2010819

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
