### PR TITLE
Bug 2011052: Use the request context when making requests to assisted-service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ lint:
 test:
 	go test ./...
 
+test-short:
+	go test -short ./...
+
+test-integration:
+	go test ./integration_test/...
+
 generate:
 	go generate $(shell go list ./...)
 	$(MAKE) format

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ skipper make test
 - `REQUEST_AUTH_TYPE` - determines how the auth token should be passed to the assisted service - either `header` or `param`
   - For `header` a header of the form `Authorization: Bearer <token>` is used
   - For `param` an `api_key=<token>` query parameter is added to the URL
+- `MAX_CONCURRENT_REQUESTS` - caps the number of inflight image downloads to avoid things like open file limits
 
 Example `RHCOS_VERSIONS`:
 ```json

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/diskfs/go-diskfs v1.2.0
 	github.com/frankban/quicktest v1.13.0 // indirect
 	github.com/golang/mock v1.6.0
+	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0

--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -1,0 +1,204 @@
+package integration_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/cavaliercoder/go-cpio"
+	diskfs "github.com/diskfs/go-diskfs"
+	"github.com/google/uuid"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/openshift/assisted-image-service/internal/handlers"
+	"github.com/openshift/assisted-image-service/pkg/imagestore"
+	"github.com/openshift/assisted-image-service/pkg/isoeditor"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	versions = []map[string]string{
+		{
+			"openshift_version": "pre-release",
+			"cpu_architecture":  "arm64",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/pre-release/latest/rhcos-live.aarch64.iso",
+			"rootfs_url":        "https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/pre-release/latest/rhcos-live-rootfs.aarch64.img",
+		},
+		{
+			"openshift_version": "4.8",
+			"cpu_architecture":  "x86_64",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.8/latest/rhcos-live.x86_64.iso",
+			"rootfs_url":        "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.8/latest/rhcos-live-rootfs.x86_64.img",
+		},
+		{
+			"openshift_version": "pre-release",
+			"cpu_architecture":  "x86_64",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest/rhcos-live.x86_64.iso",
+			"rootfs_url":        "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest/rhcos-live-rootfs.x86_64.img",
+		},
+	}
+
+	imageDir   string
+	imageStore imagestore.ImageStore
+)
+
+var _ = Describe("Image integration tests", func() {
+	var (
+		isoFilename    string
+		imageID        string
+		assistedServer *ghttp.Server
+		imageServer    *httptest.Server
+		imageClient    *http.Client
+	)
+
+	testcases := []struct {
+		name             string
+		imageType        string
+		expectedIgnition []byte
+		expectedRamdisk  []byte
+	}{
+		{
+			name:             "full-iso",
+			imageType:        imagestore.ImageTypeFull,
+			expectedIgnition: []byte("someignitioncontent"),
+			expectedRamdisk:  nil,
+		},
+		{
+			name:             "minimal-iso-with-initrd",
+			imageType:        imagestore.ImageTypeMinimal,
+			expectedIgnition: []byte("someignitioncontent"),
+			expectedRamdisk:  []byte("someramdiskcontent"),
+		},
+		{
+			name:             "minimal-iso-without-initrd",
+			imageType:        imagestore.ImageTypeMinimal,
+			expectedIgnition: []byte("someignitioncontent"),
+			expectedRamdisk:  []byte(""),
+		},
+	}
+
+	for i := range testcases {
+		tc := testcases[i]
+
+		Context(tc.name, func() {
+			BeforeEach(func() {
+				imageID = uuid.New().String()
+
+				// Set up assisted service
+				assistedServer = ghttp.NewServer()
+				u, err := url.Parse(assistedServer.URL())
+				Expect(err).NotTo(HaveOccurred())
+				assistedServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/downloads/files", imageID), "file_name=discovery.ign"),
+						ghttp.RespondWith(http.StatusOK, tc.expectedIgnition),
+					),
+				)
+				if tc.expectedRamdisk != nil {
+					assistedServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/downloads/minimal-initrd", imageID)),
+							ghttp.RespondWith(http.StatusOK, tc.expectedRamdisk),
+						),
+					)
+				}
+
+				// Set up image handler
+				reg := prometheus.NewRegistry()
+				handler := handlers.NewImageHandler(imageStore, reg, u.Scheme, u.Host, "", "", 1)
+				imageServer = httptest.NewServer(handler)
+				imageClient = imageServer.Client()
+			})
+
+			AfterEach(func() {
+				assistedServer.Close()
+				imageServer.Close()
+				Expect(os.Remove(isoFilename)).To(Succeed())
+			})
+
+			for i := range versions {
+				version := versions[i]
+
+				It("returns a properly generated "+tc.name+" iso image", func() {
+					By("getting an iso")
+					path := fmt.Sprintf("/images/%s?version=%s&type=%s&arch=%s", imageID, version["openshift_version"], tc.imageType, version["cpu_architecture"])
+					resp, err := imageClient.Get(imageServer.URL + path)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+					isoFile, err := ioutil.TempFile("", fmt.Sprintf("imageTest-%s-%s.%s.iso", version["openshift_version"], tc.name, version["cpu_architecture"]))
+					Expect(err).NotTo(HaveOccurred())
+					_, err = io.Copy(isoFile, resp.Body)
+					Expect(err).NotTo(HaveOccurred())
+					isoFilename = isoFile.Name()
+
+					By("opening the iso")
+					d, err := diskfs.OpenWithMode(isoFilename, diskfs.ReadOnly)
+					Expect(err).NotTo(HaveOccurred())
+					fs, err := d.GetFilesystem(0)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("verifying ignition content")
+					f, err := fs.OpenFile("/images/ignition.img", os.O_RDONLY)
+					Expect(err).NotTo(HaveOccurred())
+					gzipReader, err := gzip.NewReader(f)
+					Expect(err).NotTo(HaveOccurred())
+					cpioReader := cpio.NewReader(gzipReader)
+					hdr, err := cpioReader.Next()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(hdr.Name).To(Equal("config.ign"))
+					Expect(hdr.Size).To(Equal(int64(len(tc.expectedIgnition))))
+					content, err := ioutil.ReadAll(cpioReader)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(content).To(Equal(tc.expectedIgnition))
+
+					if tc.expectedRamdisk != nil {
+						By("verifying ramdisk content")
+						f, err := fs.OpenFile("/images/assisted_installer_custom.img", os.O_RDONLY)
+						Expect(err).NotTo(HaveOccurred())
+
+						content, err := ioutil.ReadAll(f)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(bytes.TrimRight(content, "\x00")).To(Equal(tc.expectedRamdisk))
+					}
+				})
+			}
+		})
+	}
+})
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	imageDir, err = ioutil.TempDir("", "imagesTest")
+	Expect(err).To(BeNil())
+
+	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir), imageDir, versions)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = imageStore.Populate(context.Background())
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	Expect(os.RemoveAll(imageDir)).To(Succeed())
+})
+
+func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration testing in short mode")
+		return
+	}
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "image building tests")
+}

--- a/internal/handlers/images.go
+++ b/internal/handlers/images.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/assisted-image-service/pkg/imagestore"
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	metrics "github.com/slok/go-http-metrics/metrics/prometheus"
 	"github.com/slok/go-http-metrics/middleware"
@@ -62,8 +63,9 @@ func parseImageID(path string) (string, error) {
 	return match[1], nil
 }
 
-func NewImageHandler(is imagestore.ImageStore, assistedServiceScheme, assistedServiceHost, requestAuthType, caCertFile string, maxRequests int) http.Handler {
+func NewImageHandler(is imagestore.ImageStore, reg *prometheus.Registry, assistedServiceScheme, assistedServiceHost, requestAuthType, caCertFile string, maxRequests int) http.Handler {
 	metricsConfig := metrics.Config{
+		Registry:        reg,
 		Prefix:          "assisted_image_service",
 		DurationBuckets: []float64{.1, 1, 10, 50, 100, 300, 600},
 		SizeBuckets:     []float64{100, 1e6, 5e8, 1e9, 1e10},

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	"github.com/openshift/assisted-image-service/pkg/imagestore"
+	"golang.org/x/sync/semaphore"
 )
 
 func TestHandlers(t *testing.T) {
@@ -120,7 +121,7 @@ var _ = Describe("ServeHTTP", func() {
 					AssistedServiceHost:   u.Host,
 					AssistedServiceScheme: u.Scheme,
 					Client:                http.DefaultClient,
-					sem:                   make(chan struct{}, 100),
+					sem:                   semaphore.NewWeighted(100),
 				}
 				server = httptest.NewServer(handler)
 				client = server.Client()
@@ -230,7 +231,7 @@ var _ = Describe("ServeHTTP", func() {
 				AssistedServiceScheme: u.Scheme,
 				RequestAuthType:       RequestAuthTypeHeader,
 				Client:                http.DefaultClient,
-				sem:                   make(chan struct{}, 100),
+				sem:                   semaphore.NewWeighted(100),
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()
@@ -267,7 +268,7 @@ var _ = Describe("ServeHTTP", func() {
 				AssistedServiceScheme: u.Scheme,
 				RequestAuthType:       RequestAuthTypeParam,
 				Client:                http.DefaultClient,
-				sem:                   make(chan struct{}, 100),
+				sem:                   semaphore.NewWeighted(100),
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -120,6 +120,7 @@ var _ = Describe("ServeHTTP", func() {
 					AssistedServiceHost:   u.Host,
 					AssistedServiceScheme: u.Scheme,
 					Client:                http.DefaultClient,
+					sem:                   make(chan struct{}, 100),
 				}
 				server = httptest.NewServer(handler)
 				client = server.Client()
@@ -229,6 +230,7 @@ var _ = Describe("ServeHTTP", func() {
 				AssistedServiceScheme: u.Scheme,
 				RequestAuthType:       RequestAuthTypeHeader,
 				Client:                http.DefaultClient,
+				sem:                   make(chan struct{}, 100),
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()
@@ -265,6 +267,7 @@ var _ = Describe("ServeHTTP", func() {
 				AssistedServiceScheme: u.Scheme,
 				RequestAuthType:       RequestAuthTypeParam,
 				Client:                http.DefaultClient,
+				sem:                   make(chan struct{}, 100),
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var Options struct {
 	HTTPSCAFile           string `envconfig:"HTTPS_CA_FILE"`
 	ListenPort            string `envconfig:"LISTEN_PORT" default:"8080"`
 	RequestAuthType       string `envconfig:"REQUEST_AUTH_TYPE"`
+	MaxConcurrentRequests int    `envconfig:"MAX_CONCURRENT_REQUESTS" default:"400"`
 }
 
 func main() {
@@ -40,7 +41,7 @@ func main() {
 		log.Fatalf("Failed to populate image store: %v\n", err)
 	}
 
-	http.Handle("/images/", handlers.NewImageHandler(is, Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.RequestAuthType, Options.HTTPSCAFile))
+	http.Handle("/images/", handlers.NewImageHandler(is, Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.RequestAuthType, Options.HTTPSCAFile, Options.MaxConcurrentRequests))
 	http.Handle("/health", handlers.NewHealthHandler())
 	http.Handle("/metrics", promhttp.Handler())
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ var Options struct {
 	HTTPSCAFile           string `envconfig:"HTTPS_CA_FILE"`
 	ListenPort            string `envconfig:"LISTEN_PORT" default:"8080"`
 	RequestAuthType       string `envconfig:"REQUEST_AUTH_TYPE"`
-	MaxConcurrentRequests int    `envconfig:"MAX_CONCURRENT_REQUESTS" default:"400"`
+	MaxConcurrentRequests int64  `envconfig:"MAX_CONCURRENT_REQUESTS" default:"400"`
 	RHCOSVersions         string `envconfig:"RHCOS_VERSIONS"`
 }
 


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

Backports #27 #28 and #29

The bug is fixed by #29, but not having the other changes was failing the cherry-pick to 2.4

#27 adds the request max which is effectively reimplemented in #29 
#28 adds some integration tests and makes minimal changes to the service itself

Those two seem safe to backport in order to avoid manually resolving the conflict.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
An image with this change was deployed to OpenShift alongside assisted service where I confirmed that canceling a download request on the client killed the running nmstatectl processes in the assisted service pod.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @djzager 
/cc @celebdor 

## Links
<!--
List any applicable links to related PRs or issues
-->
https://bugzilla.redhat.com/show_bug.cgi?id=2011052

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
