### PR TITLE
Make Ignition archiving code public

### DIFF
--- a/pkg/isoeditor/ignition.go
+++ b/pkg/isoeditor/ignition.go
@@ -1,0 +1,41 @@
+package isoeditor
+
+import (
+	"bytes"
+	"compress/gzip"
+
+	"github.com/cavaliercoder/go-cpio"
+	"github.com/pkg/errors"
+)
+
+type IgnitionContent struct {
+	Config []byte
+}
+
+func (ic *IgnitionContent) Archive() (*bytes.Reader, error) {
+	// Run gzip compression
+	compressedBuffer := new(bytes.Buffer)
+	gzipWriter := gzip.NewWriter(compressedBuffer)
+	// Create CPIO archive
+	cpioWriter := cpio.NewWriter(gzipWriter)
+
+	if err := cpioWriter.WriteHeader(&cpio.Header{
+		Name: "config.ign",
+		Mode: 0o100_644,
+		Size: int64(len(ic.Config)),
+	}); err != nil {
+		return nil, errors.Wrap(err, "Failed to write CPIO header")
+	}
+	if _, err := cpioWriter.Write(ic.Config); err != nil {
+		return nil, errors.Wrap(err, "Failed to write CPIO archive")
+	}
+
+	if err := cpioWriter.Close(); err != nil {
+		return nil, errors.Wrap(err, "Failed to close CPIO archive")
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return nil, errors.Wrap(err, "Failed to gzip ignition config")
+	}
+
+	return bytes.NewReader(compressedBuffer.Bytes()), nil
+}

--- a/pkg/isoeditor/ignition_test.go
+++ b/pkg/isoeditor/ignition_test.go
@@ -1,0 +1,33 @@
+package isoeditor
+
+import (
+	"io"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IgnitionContent.Archive", func() {
+	var (
+		ignitionContent      = []byte("someignitioncontent")
+		ignitionArchiveBytes = []byte{
+			31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 50, 48, 55, 48, 55, 48,
+			52, 128, 0, 48, 109, 97, 232, 104, 98, 128, 29, 24, 162, 113, 141, 113,
+			168, 67, 7, 78, 48, 70, 114, 126, 94, 90, 102, 186, 94, 102, 122, 30,
+			3, 3, 3, 67, 113, 126, 110, 106, 102, 122, 94, 102, 73, 102, 126, 94,
+			114, 126, 94, 73, 106, 94, 9, 3, 138, 123, 8, 1, 98, 213, 225, 116,
+			79, 72, 144, 163, 167, 143, 107, 144, 162, 162, 34, 200, 61, 128, 0, 0,
+			0, 255, 255, 191, 236, 44, 242, 12, 1, 0, 0}
+	)
+
+	It("converts the ignition to a compressed CPIO archive", func() {
+		content := IgnitionContent{ignitionContent}
+
+		data, err := content.Archive()
+		Expect(err).NotTo(HaveOccurred())
+
+		ignitionBytes, err := io.ReadAll(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ignitionBytes).To(Equal(ignitionArchiveBytes))
+	})
+})

--- a/pkg/isoeditor/stream.go
+++ b/pkg/isoeditor/stream.go
@@ -12,21 +12,26 @@ import (
 
 const ignitionImagePath = "/images/ignition.img"
 
-type StreamGeneratorFunc func(isoPath string, ignitionContent []byte, ramdiskContent []byte) (io.ReadSeeker, error)
+type StreamGeneratorFunc func(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (io.ReadSeeker, error)
 
-func NewRHCOSStreamReader(isoPath string, ignitionContent []byte, ramdiskContent []byte) (io.ReadSeeker, error) {
+func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (io.ReadSeeker, error) {
 	isoReader, err := os.Open(isoPath)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := readerForContent(isoPath, ignitionImagePath, isoReader, ignitionContent)
+	ignitionReader, err := ignitionContent.Archive()
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := readerForContent(isoPath, ignitionImagePath, isoReader, ignitionReader)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create overwrite reader for ignition")
 	}
 
 	if ramdiskContent != nil {
-		r, err = readerForContent(isoPath, ramDiskImagePath, r, ramdiskContent)
+		r, err = readerForContent(isoPath, ramDiskImagePath, r, bytes.NewReader(ramdiskContent))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create overwrite reader for ramdisk")
 		}
@@ -35,13 +40,12 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent []byte, ramdiskContent
 	return r, nil
 }
 
-func readerForContent(isoPath string, filePath string, base io.ReadSeeker, content []byte) (io.ReadSeeker, error) {
+func readerForContent(isoPath string, filePath string, base io.ReadSeeker, contentReader *bytes.Reader) (io.ReadSeeker, error) {
 	start, length, err := GetISOFileInfo(filePath, isoPath)
 	if err != nil {
 		return nil, err
 	}
 
-	contentReader := bytes.NewReader(content)
 	if length < contentReader.Size() {
 		return nil, errors.New(fmt.Sprintf("content length (%d) exceeds embed area size (%d)", contentReader.Size(), length))
 	}

--- a/pkg/isoeditor/stream_test.go
+++ b/pkg/isoeditor/stream_test.go
@@ -12,8 +12,19 @@ import (
 
 var _ = Describe("NewRHCOSStreamReader", func() {
 	var (
-		isoFile  string
-		filesDir string
+		isoFile         string
+		filesDir        string
+		ignitionContent = []byte("someignitioncontent")
+		// Note: trailing 0 bytes are omitted because we are comparing to file
+		// content that has trailing 0 bytes stripped.
+		ignitionArchiveBytes = []byte{
+			31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 50, 48, 55, 48, 55, 48,
+			52, 128, 0, 48, 109, 97, 232, 104, 98, 128, 29, 24, 162, 113, 141, 113,
+			168, 67, 7, 78, 48, 70, 114, 126, 94, 90, 102, 186, 94, 102, 122, 30,
+			3, 3, 3, 67, 113, 126, 110, 106, 102, 122, 94, 102, 73, 102, 126, 94,
+			114, 126, 94, 73, 106, 94, 9, 3, 138, 123, 8, 1, 98, 213, 225, 116,
+			79, 72, 144, 163, 167, 143, 107, 144, 162, 162, 34, 200, 61, 128, 0, 0,
+			0, 255, 255, 191, 236, 44, 242, 12, 1}
 	)
 
 	BeforeEach(func() {
@@ -42,8 +53,7 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 	}
 
 	It("embeds the ignition with no ramdisk content", func() {
-		ignitionContent := []byte("someignitioncontent")
-		streamReader, err := NewRHCOSStreamReader(isoFile, ignitionContent, nil)
+		streamReader, err := NewRHCOSStreamReader(isoFile, &IgnitionContent{ignitionContent}, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		f, err := os.CreateTemp(filesDir, "streamed*.iso")
@@ -53,13 +63,12 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 		Expect(f.Sync()).To(Succeed())
 		Expect(f.Close()).To(Succeed())
 
-		Expect(isoFileContent(f.Name(), ignitionImagePath)).To(Equal(ignitionContent))
+		Expect(isoFileContent(f.Name(), ignitionImagePath)).To(Equal(ignitionArchiveBytes))
 	})
 
 	It("embeds the ignition and ramdisk content", func() {
-		ignitionContent := []byte("someignitioncontent")
 		initrdContent := []byte("someramdiskcontent")
-		streamReader, err := NewRHCOSStreamReader(isoFile, ignitionContent, initrdContent)
+		streamReader, err := NewRHCOSStreamReader(isoFile, &IgnitionContent{ignitionContent}, initrdContent)
 		Expect(err).NotTo(HaveOccurred())
 
 		f, err := os.CreateTemp(filesDir, "streamed*.iso")
@@ -69,7 +78,7 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 		Expect(f.Sync()).To(Succeed())
 		Expect(f.Close()).To(Succeed())
 
-		Expect(isoFileContent(f.Name(), ignitionImagePath)).To(Equal(ignitionContent))
+		Expect(isoFileContent(f.Name(), ignitionImagePath)).To(Equal(ignitionArchiveBytes))
 		Expect(isoFileContent(f.Name(), ramDiskImagePath)).To(Equal(initrdContent))
 	})
 })


### PR DESCRIPTION
## Description
All users of NewRHCOSStreamReader will need to convert the image data to
a gzip-compressed CPIO archive, so move this code out of the internal
package. To ensure future compatibility (e.g. if more than one file had
to be inserted in the archive), implement this code in a new
IgnitionContent type.

## How was this code tested?
Unit tests

## Assignees
/cc @carbonin 

## Links
https://github.com/openshift/image-customization-controller/pull/4#discussion_r726219950

## Checklist

- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
