### PR TITLE
Bug 2012796: Add liveness endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,12 @@ Downloads the RHCOS image for the specified image ID.
 
 ### `GET /health`
 
+Returns 503 until the images are downloaded
 Returns 200 if the service is ready to respond to requests
+
+### `GET /live`
+
+Returns 200 if the service is running
 
 ### `GET /metrics`
 

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -302,3 +302,22 @@ var _ = Describe("parseImageID", func() {
 		Expect(err).To(HaveOccurred())
 	})
 })
+
+var _ = Describe("readiness handler", func() {
+	It("Not ready to Ready", func() {
+		readinessHandler := NewReadinessHandler()
+		server := httptest.NewServer(readinessHandler)
+		defer server.Close()
+
+		resp, err := server.Client().Get(server.URL + "/ready")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusServiceUnavailable))
+
+		By("Enable readiness handler")
+		readinessHandler.Enable()
+
+		resp, err = server.Client().Get(server.URL + "/ready")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	})
+})

--- a/internal/handlers/liveness.go
+++ b/internal/handlers/liveness.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 )
 
-func NewHealthHandler() http.Handler {
+func NewLivenessHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/internal/handlers/readiness.go
+++ b/internal/handlers/readiness.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type ReadinessHandler struct {
+	isEnabled bool
+}
+
+func NewReadinessHandler() *ReadinessHandler {
+	return &ReadinessHandler{
+		isEnabled: false,
+	}
+}
+
+func (a *ReadinessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !a.isEnabled {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (a *ReadinessHandler) Enable() {
+	a.isEnabled = true
+	log.Info("API is enabled")
+}


### PR DESCRIPTION
-## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->
- Add new endpoint `live`, that always respond 200.
- Change endpoint `health` to respond 503 until the `Populate` is done.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
- Run the service
- Call for /live and check return code is 200 from the start of the service, during and after `Populate`.
- Call for /health during 'Populate' and check return code is 503.
- Call for /health after 'Populate' and check return code is 200.
- 
## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
