### PR TITLE
MGMT-7897: Rework authentication handling to support image_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ skipper make test
 - `HTTPS_CERT_FILE` - tls cert file path
 - `ASSISTED_SERVICE_SCHEME` - protocol to use to query assisted service for image information
 - `ASSISTED_SERVICE_HOST` - host or host:port to use to query assisted service for image information
-- `REQUEST_AUTH_TYPE` - determines how the auth token should be passed to the assisted service - either `header` or `param`
-  - For `header` a header of the form `Authorization: Bearer <token>` is used
-  - For `param` an `api_key=<token>` query parameter is added to the URL
 - `MAX_CONCURRENT_REQUESTS` - caps the number of inflight image downloads to avoid things like open file limits
 
 Example `RHCOS_VERSIONS`:
@@ -69,7 +66,12 @@ Downloads the RHCOS image for the specified image ID.
 - `version`: indicates the version of the RHCOS base image to use (must match an entry in `RHCOS_VERSIONS`)
 - `arch`: the base image cpu architecture (must match an entry in `RHCOS_VERSIONS`)
 - `type`: `full-iso` to download the ISO including the rootfs, `minimal-iso` to download the iso without the rootfs
-- `api_key`: the api token to pass through to the assisted service calls if authentication is required
+- `api_key`: the api token to pass through to the assisted service calls if local authentication is required
+- `image_token`: the token to pass through to the Image-Token assisted service header if image pre-signed authentication is required
+
+#### Headers
+
+- `Authorization`: this header is passed directly through to assisted service requests to handle RHSSO authentication
 
 ### `GET /health`
 
@@ -83,3 +85,14 @@ Returns 200 if the service is running
 ### `GET /metrics`
 
 Prometheus metrics scraping endpoint
+
+## Authentication
+
+Authentication tokens are accepted in various ways to support different deployment models and assisted service authentication backends
+The following table shows how each authentication input is translated when making calls to assisted service
+
+| Image Service                 | Assisted Service          |
+|-------------------------------|---------------------------|
+| `api_key` query parameter     | `api_key` query parameter |
+| `image_token` query parameter | `Image-Token` header      |
+| `Authorization` header        | `Authorization` header    |

--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Image integration tests", func() {
 
 				// Set up image handler
 				reg := prometheus.NewRegistry()
-				handler := handlers.NewImageHandler(imageStore, reg, u.Scheme, u.Host, "", "", 1)
+				handler := handlers.NewImageHandler(imageStore, reg, u.Scheme, u.Host, "", 1)
 				imageServer = httptest.NewServer(handler)
 				imageClient = imageServer.Client()
 			})

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ var Options struct {
 	HTTPSCertFile         string `envconfig:"HTTPS_CERT_FILE"`
 	HTTPSCAFile           string `envconfig:"HTTPS_CA_FILE"`
 	ListenPort            string `envconfig:"LISTEN_PORT" default:"8080"`
-	RequestAuthType       string `envconfig:"REQUEST_AUTH_TYPE"`
 	MaxConcurrentRequests int64  `envconfig:"MAX_CONCURRENT_REQUESTS" default:"400"`
 	RHCOSVersions         string `envconfig:"RHCOS_VERSIONS"`
 }
@@ -62,7 +61,7 @@ func main() {
 	}()
 
 	reg := prometheus.NewRegistry()
-	http.Handle("/images/", handlers.NewImageHandler(is, reg, Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.RequestAuthType, Options.HTTPSCAFile, Options.MaxConcurrentRequests))
+	http.Handle("/images/", handlers.NewImageHandler(is, reg, Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.HTTPSCAFile, Options.MaxConcurrentRequests))
 	http.Handle("/health", readinessHandler)
 	http.Handle("/live", handlers.NewLivenessHandler())
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))


### PR DESCRIPTION


## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

This commit changes how the image service handles authentication
parameters. Previously an environment variable (`REQUEST_AUTH_TYPE`) was
used to change how the image service would treat the `api_key` query
parameter.

This didn't end up working out as we want to use a different query
parameter name for different auth types and the effect of changing
`REQUEST_AUTH_TYPE` was unclear.

This commit removes `REQUEST_AUTH_TYPE` and implements separate handling
for each authentication strategy. This should clear up how what is passed
to the image service gets used in calls to assisted service.

Specifically the mappings are now:
| image service auth            | assisted service auth     |
|-------------------------------|---------------------------|
| `api_key` query parameter     | `api_key` query parameter |
| `image_token` query parameter | `Image-Token` header      |
| `Authorization` header        | `Authorization` header    |

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

I ran an image built with this code configured with an assisted-service installation deployed with the changes in https://github.com/openshift/assisted-service/pull/2824 and was able to successfully download an image using a url the new token auth.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @rollandf 
/cc @danielerez 

## Links
<!--
List any applicable links to related PRs or issues
-->

https://github.com/openshift/assisted-service/pull/2824
https://issues.redhat.com/browse/MGMT-7897

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
