### PR TITLE
Add the ability to customise PXE files

### DIFF
--- a/pkg/isoeditor/initramfs.go
+++ b/pkg/isoeditor/initramfs.go
@@ -1,0 +1,27 @@
+package isoeditor
+
+import (
+	"io"
+	"os"
+
+	"github.com/openshift/assisted-image-service/pkg/overlay"
+	"github.com/pkg/errors"
+)
+
+func NewInitRamFSStreamReader(irfsPath string, ignitionContent *IgnitionContent) (io.ReadSeeker, error) {
+	irfsReader, err := os.Open(irfsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	ignitionReader, err := ignitionContent.Archive()
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := overlay.NewAppendReader(irfsReader, ignitionReader)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create append reader for ignition")
+	}
+	return r, nil
+}

--- a/pkg/isoeditor/initramfs_test.go
+++ b/pkg/isoeditor/initramfs_test.go
@@ -1,0 +1,48 @@
+package isoeditor
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewInitRamFSStreamReader", func() {
+	var (
+		ignitionContent      = []byte("someignitioncontent")
+		ignitionArchiveBytes = []byte{
+			31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 50, 48, 55, 48, 55, 48,
+			52, 128, 0, 48, 109, 97, 232, 104, 98, 128, 29, 24, 162, 113, 141, 113,
+			168, 67, 7, 78, 48, 70, 114, 126, 94, 90, 102, 186, 94, 102, 122, 30,
+			3, 3, 3, 67, 113, 126, 110, 106, 102, 122, 94, 102, 73, 102, 126, 94,
+			114, 126, 94, 73, 106, 94, 9, 3, 138, 123, 8, 1, 98, 213, 225, 116,
+			79, 72, 144, 163, 167, 143, 107, 144, 162, 162, 34, 200, 61, 128, 0, 0,
+			0, 255, 255, 191, 236, 44, 242, 12, 1, 0, 0}
+	)
+
+	filesDir, _ := createTestFiles("Assisted123")
+	initrdPath := filepath.Join(filesDir, "images/ignition.img")
+
+	It("appends the ignition", func() {
+		streamReader, err := NewInitRamFSStreamReader(initrdPath, &IgnitionContent{ignitionContent})
+		Expect(err).NotTo(HaveOccurred())
+
+		var output, expected strings.Builder
+		_, err = io.Copy(&output, streamReader)
+		Expect(err).NotTo(HaveOccurred())
+
+		initReader, err := os.Open(initrdPath)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = io.Copy(&expected, initReader)
+		Expect(err).NotTo(HaveOccurred())
+		err = initReader.Close()
+		Expect(err).NotTo(HaveOccurred())
+		_, err = expected.Write(ignitionArchiveBytes)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(output.String()).To(Equal(expected.String()))
+	})
+})

--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -59,6 +59,25 @@ func NewOverlayReader(base io.ReadSeeker, overlay Overlay) (io.ReadSeeker, error
 	return newReader(base, overlay, length)
 }
 
+func NewAppendReader(base io.ReadSeeker, reader io.ReadSeeker) (io.ReadSeeker, error) {
+	length, err := base.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, err
+	}
+
+	appendLength, err := reader.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, err
+	}
+
+	overlay := Overlay{
+		Reader: reader,
+		Offset: length,
+		Length: appendLength,
+	}
+	return newReader(base, overlay, length)
+}
+
 func (or *overlayReader) seek(index int64) (err error) {
 	if or.Overlay.contains(index) {
 		_, err = or.Overlay.Reader.Seek(index-or.Overlay.Offset, io.SeekStart)

--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -27,14 +27,7 @@ type overlayReader struct {
 	totalLength int64
 }
 
-func NewOverlayReader(base io.ReadSeeker, overlay Overlay) (io.ReadSeeker, error) {
-	length, err := base.Seek(0, io.SeekEnd)
-	if err != nil {
-		return nil, err
-	}
-	if overlay.Offset < 0 || overlay.Offset > length {
-		return nil, errors.New("Overlay offset is beyond end of base")
-	}
+func newReader(base io.ReadSeeker, overlay Overlay, length int64) (*overlayReader, error) {
 	if overlay.end() > length {
 		length = overlay.end()
 	}
@@ -53,6 +46,17 @@ func NewOverlayReader(base io.ReadSeeker, overlay Overlay) (io.ReadSeeker, error
 	}
 
 	return &or, nil
+}
+
+func NewOverlayReader(base io.ReadSeeker, overlay Overlay) (io.ReadSeeker, error) {
+	length, err := base.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, err
+	}
+	if overlay.Offset < 0 || overlay.Offset > length {
+		return nil, errors.New("Overlay offset is beyond end of base")
+	}
+	return newReader(base, overlay, length)
 }
 
 func (or *overlayReader) seek(index int64) (err error) {

--- a/pkg/overlay/overlay_test.go
+++ b/pkg/overlay/overlay_test.go
@@ -107,3 +107,17 @@ var _ = Describe("OverlayReader", func() {
 		}
 	})
 })
+
+var _ = Describe("AppendReader", func() {
+
+	base := "abcdefghij"
+	appendString := "overlay"
+	expected := base + appendString
+
+	reader, err := NewAppendReader(strings.NewReader(base), strings.NewReader(appendString))
+	Expect(err).NotTo(HaveOccurred())
+
+	output, err := io.ReadAll(reader)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(output)).To(Equal(expected))
+})


### PR DESCRIPTION
In addition to the existing `NewRHCOSStreamReader()` function to generate a streamable customised ISO file, add a new `NewInitRamFSStreamReader()` function to do equivalent customisation of an initramfs file for the purposes of PXE booting.

The [initramfs format](https://www.kernel.org/doc/html/latest/driver-api/early-userspace/buffer-format.html) consists of a sequence of gzipped cpio archives (each archive is gzipped separately), so the customisation can be performed by simply appending a new archive at the end of the stream. The archive itself is identical to the one used to customise the ISO.