### PR TITLE
Close the ISO file after serving a request

### DIFF
--- a/internal/handlers/images.go
+++ b/internal/handlers/images.go
@@ -144,6 +144,7 @@ func (h *ImageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer isoReader.Close()
 
 	//TODO: set modified time correctly (MGMT-7274)
 

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -106,7 +106,7 @@ var _ = Describe("ServeHTTP", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				initrdContent = nil
-				mockImageStream := func(isoPath string, ignition *isoeditor.IgnitionContent, ramdiskBytes []byte) (io.ReadSeeker, error) {
+				mockImageStream := func(isoPath string, ignition *isoeditor.IgnitionContent, ramdiskBytes []byte) (isoeditor.ImageReader, error) {
 					defer GinkgoRecover()
 					Expect(ignition.Config).To(Equal([]byte(ignitionContent)))
 					if isoPath == minImageFilename {
@@ -218,7 +218,7 @@ var _ = Describe("ServeHTTP", func() {
 			u, err := url.Parse(assistedServer.URL())
 			Expect(err).NotTo(HaveOccurred())
 
-			mockImageStream := func(isoPath string, ignition *isoeditor.IgnitionContent, ramdiskBytes []byte) (io.ReadSeeker, error) {
+			mockImageStream := func(isoPath string, ignition *isoeditor.IgnitionContent, ramdiskBytes []byte) (isoeditor.ImageReader, error) {
 				defer GinkgoRecover()
 				Expect(ignition.Config).To(Equal([]byte(ignitionContent)))
 				return os.Open(isoPath)
@@ -258,7 +258,7 @@ var _ = Describe("ServeHTTP", func() {
 			u, err := url.Parse(assistedServer.URL())
 			Expect(err).NotTo(HaveOccurred())
 
-			mockImageStream := func(isoPath string, ignition *isoeditor.IgnitionContent, ramdiskBytes []byte) (io.ReadSeeker, error) {
+			mockImageStream := func(isoPath string, ignition *isoeditor.IgnitionContent, ramdiskBytes []byte) (isoeditor.ImageReader, error) {
 				defer GinkgoRecover()
 				Expect(ignition.Config).To(Equal([]byte(ignitionContent)))
 				return os.Open(isoPath)
@@ -295,7 +295,7 @@ var _ = Describe("ServeHTTP", func() {
 			u, err := url.Parse(assistedServer.URL())
 			Expect(err).NotTo(HaveOccurred())
 
-			mockImageStream := func(isoPath string, ignition *isoeditor.IgnitionContent, ramdiskBytes []byte) (io.ReadSeeker, error) {
+			mockImageStream := func(isoPath string, ignition *isoeditor.IgnitionContent, ramdiskBytes []byte) (isoeditor.ImageReader, error) {
 				defer GinkgoRecover()
 				Expect(ignition.Config).To(Equal([]byte(ignitionContent)))
 				return os.Open(isoPath)

--- a/pkg/isoeditor/initramfs.go
+++ b/pkg/isoeditor/initramfs.go
@@ -1,14 +1,13 @@
 package isoeditor
 
 import (
-	"io"
 	"os"
 
 	"github.com/openshift/assisted-image-service/pkg/overlay"
 	"github.com/pkg/errors"
 )
 
-func NewInitRamFSStreamReader(irfsPath string, ignitionContent *IgnitionContent) (io.ReadSeeker, error) {
+func NewInitRamFSStreamReader(irfsPath string, ignitionContent *IgnitionContent) (overlay.OverlayReader, error) {
 	irfsReader, err := os.Open(irfsPath)
 	if err != nil {
 		return nil, err

--- a/pkg/isoeditor/stream.go
+++ b/pkg/isoeditor/stream.go
@@ -12,9 +12,11 @@ import (
 
 const ignitionImagePath = "/images/ignition.img"
 
-type StreamGeneratorFunc func(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (io.ReadSeeker, error)
+type ImageReader = overlay.OverlayReader
 
-func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (io.ReadSeeker, error) {
+type StreamGeneratorFunc func(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (ImageReader, error)
+
+func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (ImageReader, error) {
 	isoReader, err := os.Open(isoPath)
 	if err != nil {
 		return nil, err
@@ -40,7 +42,7 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 	return r, nil
 }
 
-func readerForContent(isoPath string, filePath string, base io.ReadSeeker, contentReader *bytes.Reader) (io.ReadSeeker, error) {
+func readerForContent(isoPath string, filePath string, base io.ReadSeeker, contentReader *bytes.Reader) (overlay.OverlayReader, error) {
 	start, length, err := GetISOFileInfo(filePath, isoPath)
 	if err != nil {
 		return nil, err

--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -9,7 +9,7 @@ type BaseStream = io.ReadSeeker
 
 type OverlayReader interface {
 	BaseStream
-	io.ReadSeeker
+	io.ReadSeekCloser
 }
 
 type Overlay struct {
@@ -147,4 +147,11 @@ func (or *overlayReader) Read(p []byte) (int, error) {
 		return bytesRead, readErr
 	}
 	return bytesRead, seekErr
+}
+
+func (or *overlayReader) Close() error {
+	if closer, hasClose := or.Base.(io.Closer); hasClose {
+		return closer.Close()
+	}
+	return nil
 }


### PR DESCRIPTION
It's possible that this was being cleaned up automagically so that we don't leak buffers/file descriptors/something else, but better to explicitly close the base file after the request is completed.