### PR TITLE
Add monitoring template for gathering metrics

### DIFF
--- a/deploy/template-monitoring.yaml
+++ b/deploy/template-monitoring.yaml
@@ -1,0 +1,28 @@
+---
+parameters:
+- name: NAMESPACE
+  value: ''
+  required: true
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: assisted-image-service-monitoring
+objects:
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      prometheus: app-sre
+    name: servicemonitor-image-service
+  spec:
+    endpoints:
+    - interval: 30s
+      path: /metrics
+      port: image-service
+      scheme: http
+    namespaceSelector:
+      matchNames:
+      - ${NAMESPACE}
+    selector:
+      matchLabels:
+        name: assisted-image-service

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -21,10 +21,13 @@ objects:
   kind: Service
   metadata:
     name: assisted-image-service
+    labels:
+      name: assisted-image-service
   spec:
     ports:
     - port: 8080
       protocol: TCP
+      name: image-service
     selector:
       service: image-service
 - apiVersion: apps/v1


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

This commit adds an additional template which describes the
ServiceMonitor required to collect metrics from the image service.

Additionally it makes some minor changes to the app template to make the
object references easier.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

`oc process --local -f deploy/template-monitoring.yaml -pNAMESPACE=assisted-installer-stage`
:point_up: succeeds
We'll have to wait for this to deploy to see if metrics are gathered properly.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @filanov 

## Links
<!--
List any applicable links to related PRs or issues
-->

https://issues.redhat.com/browse/MGMT-7715

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
