### PR TITLE
Set the Content-Disposition header

### DIFF
--- a/internal/handlers/images.go
+++ b/internal/handlers/images.go
@@ -149,6 +149,7 @@ func (h *ImageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	//TODO: set modified time correctly (MGMT-7274)
 
 	fileName := fmt.Sprintf("%s-discovery.iso", imageID)
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileName))
 	http.ServeContent(w, r, fileName, time.Now(), isoReader)
 }
 

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -82,6 +82,7 @@ var _ = Describe("ServeHTTP", func() {
 
 		expectSuccessfulResponse := func(resp *http.Response, content []byte) {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Header.Get("Content-Disposition")).To(Equal(fmt.Sprintf("attachment; filename=%s-discovery.iso", imageID)))
 			respContent, err := io.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(respContent).To(Equal(content))


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

This will allow clients looking for this header to automatically set the
downloaded file name to something that makes sense.


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

Ran the image service from this branch against assisted service in the stage cloud environment and downloaded an iso with the following `curl` command:

`curl -k -v -OJ -H "Authorization: Bearer $(ocm token)" "https://localhost:8080/images/d77694d1-0ee4-4812-a60b-7ac02d41c6ad?type=minimal-iso&version=4.8&arch=x86_64"`

This resulted in a file named `d77694d1-0ee4-4812-a60b-7ac02d41c6ad-discovery.iso` written in the working directory.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @danielerez 
/cc @rollandf 

## Links
<!--
List any applicable links to related PRs or issues
-->

https://bugzilla.redhat.com/show_bug.cgi?id=2015961

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
