### PR TITLE
isoeditor: support editing FCOS grub.cfg

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -49,6 +49,20 @@ var (
 			"rootfs_url":        "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest/rhcos-live-rootfs.x86_64.img",
 			"version":           "x86_64-latest",
 		},
+		{
+			"openshift_version": "fcos-pre-release",
+			"cpu_architecture":  "x86_64",
+			"url":               "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live.x86_64.iso",
+			"rootfs_url":        "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live-rootfs.x86_64.img",
+			"version":           "x86_64-latest",
+		},
+		{
+			"openshift_version": "fcos-pre-release",
+			"cpu_architecture":  "arm64",
+			"url":               "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live.aarch64.iso",
+			"rootfs_url":        "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live-initramfs.aarch64.imgg",
+			"version":           "arm-latest",
+		},
 	}
 
 	imageDir   string

--- a/pkg/isoeditor/rhcos_test.go
+++ b/pkg/isoeditor/rhcos_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	testRootFSURL = "https://example.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img"
+	testRootFSURL     = "https://example.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img"
+	testFCOSRootFSURL = "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live-rootfs.x86_64.img"
 )
 
 var _ = Context("with test files", func() {
@@ -64,6 +65,21 @@ var _ = Context("with test files", func() {
 		It("missing iso file", func() {
 			editor := NewEditor(workDir)
 			err := editor.CreateMinimalISOTemplate("invalid", testRootFSURL, minimalISOPath)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("CreateFCOSMinimalISOTemplate", func() {
+		It("iso created successfully", func() {
+			editor := NewEditor(workDir)
+
+			err := editor.CreateMinimalISOTemplate(isoFile, testFCOSRootFSURL, minimalISOPath)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("missing iso file", func() {
+			editor := NewEditor(workDir)
+			err := editor.CreateMinimalISOTemplate("invalid", testFCOSRootFSURL, minimalISOPath)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
## Description
Discovery ISO might be FCOS based, so `grub.cfg` needs to be looked up in a different path. This PR checks which of two paths - RHCOS and FCOS - is available and uses it throughout the function

## How was this code tested?
Tested AI flow with FCOS 34 as a base for ISO image

## Assignees
/cc @carbonin
/cc @rollandf 

## Links

## Checklist
- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
