### PR TITLE
Handle CORS headers properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ skipper make test
 - `ASSISTED_SERVICE_SCHEME` - protocol to use to query assisted service for image information
 - `ASSISTED_SERVICE_HOST` - host or host:port to use to query assisted service for image information
 - `MAX_CONCURRENT_REQUESTS` - caps the number of inflight image downloads to avoid things like open file limits
+- `ALLOWED_DOMAINS` - When set, determines how the service responds to requests with `Origin` headers
 
 Example `OS_IMAGES`:
 ```json

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,9 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
+	github.com/rs/cors v1.8.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/slok/go-http-metrics v0.9.0
-	github.com/thoas/go-funk v0.9.1 // indirect
+	github.com/thoas/go-funk v0.9.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/statsd_exporter v0.15.0/go.mod h1:Dv8HnkoLQkeEjkIE4/2ndAA7WL1zHKK7WMqFQqu72rw=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=
+github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/cors"
+)
+
+func WithCORSMiddleware(handler http.Handler, domains string) http.Handler {
+	domainList := strings.Split(strings.ReplaceAll(domains, " ", ""), ",")
+
+	corsHandler := cors.New(cors.Options{
+		Debug: false,
+		AllowedMethods: []string{
+			http.MethodHead,
+			http.MethodGet,
+		},
+		AllowedOrigins: domainList,
+		AllowedHeaders: []string{
+			"Authorization",
+			"Content-Type",
+		},
+		MaxAge: int((10 * time.Minute).Seconds()),
+	})
+	return corsHandler.Handler(handler)
+}

--- a/internal/handlers/middleware_test.go
+++ b/internal/handlers/middleware_test.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("WithCORSMiddleware", func() {
+	var (
+		server *httptest.Server
+		client *http.Client
+	)
+
+	BeforeEach(func() {
+		baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, "Hello!")
+		})
+		allowedURLs := "https://test.example.com, https://other.example.com"
+
+		server = httptest.NewServer(WithCORSMiddleware(baseHandler, allowedURLs))
+		client = server.Client()
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	doRequestWithOrigin := func(method, origin string) string {
+		req, err := http.NewRequest(method, server.URL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		resp, err := client.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		return resp.Header.Get("Access-Control-Allow-Origin")
+	}
+
+	It("returns the CORS header when provided an allowed domain", func() {
+		respHeaderValue := doRequestWithOrigin(http.MethodGet, "https://test.example.com")
+		Expect(respHeaderValue).To(Equal("https://test.example.com"))
+
+		respHeaderValue = doRequestWithOrigin(http.MethodGet, "https://other.example.com")
+		Expect(respHeaderValue).To(Equal("https://other.example.com"))
+
+		respHeaderValue = doRequestWithOrigin(http.MethodHead, "https://test.example.com")
+		Expect(respHeaderValue).To(Equal("https://test.example.com"))
+
+		respHeaderValue = doRequestWithOrigin(http.MethodHead, "https://other.example.com")
+		Expect(respHeaderValue).To(Equal("https://other.example.com"))
+	})
+
+	It("doesn't return the CORS header when provided a forbidden domain", func() {
+		respHeaderValue := doRequestWithOrigin(http.MethodGet, "https://nope.example.com")
+		Expect(respHeaderValue).To(Equal(""))
+
+		respHeaderValue = doRequestWithOrigin(http.MethodHead, "https://nope.example.com")
+		Expect(respHeaderValue).To(Equal(""))
+	})
+
+	It("doesn't return the CORS header when the origin header is missing", func() {
+		respHeaderValue := doRequestWithOrigin(http.MethodGet, "")
+		Expect(respHeaderValue).To(Equal(""))
+
+		respHeaderValue = doRequestWithOrigin(http.MethodHead, "")
+		Expect(respHeaderValue).To(Equal(""))
+	})
+})


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

This commit adds middleware to handle adding CORS headers to API
responses. The new env var `ALLOWED_DOMAINS` is a comma-separated list
of domains which should be allowed to access content from this API.

The CORS middleware is only used when a value is set for
`ALLOWED_DOMAINS`.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

Started the service locally with and without the new env var.
Observed the correct handling when an `Origin` request header was passed with a matching domain and a non-matching one.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @tsorya 
/cc @danielerez 

## Links
<!--
List any applicable links to related PRs or issues
-->

https://issues.redhat.com/browse/MGMT-8688

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] ~~This change does not require a documentation update (docstring, `docs`, README, etc)~~ README updated :+1: 
- [x] Does this change include unit tests (note that code changes require unit tests)
