### PR TITLE
Bug 2034686: Allow for disabling TLS verification for fetching ISOs

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -200,7 +200,7 @@ var _ = BeforeSuite(func() {
 	imageDir, err = ioutil.TempDir("", "imagesTest")
 	Expect(err).To(BeNil())
 
-	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir), imageDir, versions)
+	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir), imageDir, false, versions)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = imageStore.Populate(context.Background())

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var Options struct {
 	RHCOSVersions         string `envconfig:"RHCOS_VERSIONS"`
 	OSImages              string `envconfig:"OS_IMAGES"`
 	AllowedDomains        string `envconfig:"ALLOWED_DOMAINS"`
+	InsecureSkipVerify    bool   `envconfig:"INSECURE_SKIP_VERIFY" default:"false"`
 }
 
 func main() {
@@ -52,7 +53,7 @@ func main() {
 		}
 	}
 
-	is, err := imagestore.NewImageStore(isoeditor.NewEditor(Options.DataDir), Options.DataDir, versions)
+	is, err := imagestore.NewImageStore(isoeditor.NewEditor(Options.DataDir), Options.DataDir, Options.InsecureSkipVerify, versions)
 	if err != nil {
 		log.Fatalf("Failed to create image store: %v\n", err)
 	}

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -82,7 +82,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, []map[string]string{version})
+				is, err := NewImageStore(mockEditor, dataDir, false, []map[string]string{version})
 				Expect(err).NotTo(HaveOccurred())
 
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "http://example.com/image/48.img", gomock.Any()).Return(nil)
@@ -101,7 +101,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/fail.iso"
-				is, err := NewImageStore(mockEditor, dataDir, []map[string]string{version})
+				is, err := NewImageStore(mockEditor, dataDir, false, []map[string]string{version})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(is.Populate(ctx)).NotTo(Succeed())
@@ -115,7 +115,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, []map[string]string{version})
+				is, err := NewImageStore(mockEditor, dataDir, false, []map[string]string{version})
 				Expect(err).NotTo(HaveOccurred())
 
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "http://example.com/image/48.img", gomock.Any()).Return(fmt.Errorf("minimal iso creation failed"))
@@ -130,7 +130,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/dontcallthis.iso"
-				is, err := NewImageStore(mockEditor, dataDir, []map[string]string{version})
+				is, err := NewImageStore(mockEditor, dataDir, false, []map[string]string{version})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
@@ -140,7 +140,7 @@ var _ = Context("with a data directory configured", func() {
 			})
 
 			It("recreates the minimal iso even when it's already present", func() {
-				is, err := NewImageStore(mockEditor, dataDir, []map[string]string{version})
+				is, err := NewImageStore(mockEditor, dataDir, false, []map[string]string{version})
 				Expect(err).NotTo(HaveOccurred())
 
 				fullPath := filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso")
@@ -162,7 +162,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				versionPatch["url"] = ts.URL() + "/somepatchversion.iso"
-				is, err := NewImageStore(mockEditor, dataDir, []map[string]string{versionPatch})
+				is, err := NewImageStore(mockEditor, dataDir, false, []map[string]string{versionPatch})
 				Expect(err).NotTo(HaveOccurred())
 
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "http://example.com/image/481.img", gomock.Any()).Return(nil)
@@ -184,7 +184,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, []map[string]string{version})
+				is, err := NewImageStore(mockEditor, dataDir, false, []map[string]string{version})
 				Expect(err).NotTo(HaveOccurred())
 
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "http://example.com/image/48.img", gomock.Any()).Return(nil)
@@ -202,7 +202,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, []map[string]string{version})
+				is, err := NewImageStore(mockEditor, dataDir, false, []map[string]string{version})
 				Expect(err).NotTo(HaveOccurred())
 
 				err = is.Populate(ctx)
@@ -225,7 +225,7 @@ var _ = Describe("PathForParams", func() {
 			"rootfs_url":        "http://example.com/image/x86_64-48.img",
 			"version":           "48.84.202109241901-0",
 		}}
-		is, err := NewImageStore(nil, "/tmp/some/dir", versions)
+		is, err := NewImageStore(nil, "/tmp/some/dir", false, versions)
 		Expect(err).NotTo(HaveOccurred())
 		expected := "/tmp/some/dir/rhcos-full-4.8-48.84.202109241901-0-x86_64.iso"
 		Expect(is.PathForParams("full", "4.8", "x86_64")).To(Equal(expected))
@@ -255,7 +255,7 @@ var _ = Describe("HaveVersion", func() {
 
 	BeforeEach(func() {
 		var err error
-		store, err = NewImageStore(nil, "", versions)
+		store, err = NewImageStore(nil, "", false, versions)
 		Expect(err).NotTo(HaveOccurred())
 	})
 	AfterEach(func() {
@@ -285,13 +285,13 @@ var _ = Describe("NewImageStore", func() {
 				"version":           "48.84.202109241901-0",
 			},
 		}
-		_, err := NewImageStore(nil, "", versions)
+		_, err := NewImageStore(nil, "", false, versions)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should error when RHCOS_IMAGES are not set i.e. versions is an empty slice", func() {
 		versions := []map[string]string{}
-		_, err := NewImageStore(nil, "", versions)
+		_, err := NewImageStore(nil, "", false, versions)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("invalid versions: must not be empty"))
 
@@ -306,7 +306,7 @@ var _ = Describe("NewImageStore", func() {
 				"version":          "48.84.202109241901-0",
 			},
 		}
-		_, err := NewImageStore(nil, "", versions)
+		_, err := NewImageStore(nil, "", false, versions)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -319,7 +319,7 @@ var _ = Describe("NewImageStore", func() {
 				"version":           "48.84.202109241901-0",
 			},
 		}
-		_, err := NewImageStore(nil, "", versions)
+		_, err := NewImageStore(nil, "", false, versions)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -332,7 +332,7 @@ var _ = Describe("NewImageStore", func() {
 				"version":           "48.84.202109241901-0",
 			},
 		}
-		_, err := NewImageStore(nil, "", versions)
+		_, err := NewImageStore(nil, "", false, versions)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -345,7 +345,7 @@ var _ = Describe("NewImageStore", func() {
 				"version":           "48.84.202109241901-0",
 			},
 		}
-		_, err := NewImageStore(nil, "", versions)
+		_, err := NewImageStore(nil, "", false, versions)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -358,7 +358,7 @@ var _ = Describe("NewImageStore", func() {
 				"rootfs_url":        "http://example.com/image/x86_64-48.img",
 			},
 		}
-		_, err := NewImageStore(nil, "", versions)
+		_, err := NewImageStore(nil, "", false, versions)
 		Expect(err).To(HaveOccurred())
 	})
 })


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->
[Bugzilla 2034686](https://bugzilla.redhat.com/show_bug.cgi?id=2034686): Allow for disabling TLS verification for fetching ISOs

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
Manually tested by creating an nginx server secured with a self-signed certificate in the assisted-image-service pod, hosting a file, and updating the assisted-service-config configmap's OS_IMAGES to point to the file url.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
