### PR TITLE
MGMT-8927: build image from scratch to handle possible cleanups

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -6,7 +6,7 @@ TAG=$(git rev-parse --short=7 HEAD)
 REPO="quay.io/app-sre/assisted-image-service"
 IMAGE="${REPO}:${TAG}"
 
-docker build -f Dockerfile.image-service . -t ${IMAGE}
+docker build -f Dockerfile.image-service . -t ${IMAGE} --no-cache
 
 docker login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
 


### PR DESCRIPTION
## Description

Seems like we might fail pushing images to the app-sre namespace, depending on scheduling of cleanup jobs occurring from time to time for Jenkins agents.

This has led to the idea that it might be beneficial to build the image from scratch (including intermediate layers that should usually be cached). It's also a good idea to always build the whole image, ignoring stuff that might was buildable before but not now.

## How was this code tested?

Sadly we don't have a way to trigger cleanup or simulate it in a good way. We'll have to monitor it from time to time.
If needed, slack link includes some more suggestions based on past experience.

## Assignees

/cc @carbonin 
/cc @filanov 

## Links

https://ci.ext.devshift.net/job/openshift-assisted-image-service-gh-build-main/34/console
https://coreos.slack.com/archives/CCRND57FW/p1642341209291500


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
