### PR TITLE
Bug 2046521: Allow for disabling TLS verification for fetching ISOs.

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var Options struct {
 	HTTPSCAFile           string `envconfig:"HTTPS_CA_FILE"`
 	ListenPort            string `envconfig:"LISTEN_PORT" default:"8080"`
 	RequestAuthType       string `envconfig:"REQUEST_AUTH_TYPE"`
+	InsecureSkipVerify    bool   `envconfig:"INSECURE_SKIP_VERIFY" default:"false"`
 }
 
 func main() {
@@ -31,7 +32,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to process config: %v\n", err)
 	}
-	is, err := imagestore.NewImageStore(isoeditor.NewEditor(Options.DataDir), Options.DataDir)
+
+	is, err := imagestore.NewImageStore(isoeditor.NewEditor(Options.DataDir), Options.DataDir, Options.InsecureSkipVerify)
 	if err != nil {
 		log.Fatalf("Failed to create image store: %v\n", err)
 	}

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -22,7 +22,7 @@ func TestImageStore(t *testing.T) {
 
 var _ = Describe("NewImageStore", func() {
 	It("uses the default versions", func() {
-		is, err := NewImageStore(nil, "")
+		is, err := NewImageStore(nil, "", false)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(is.(*rhcosStore).versions).To(Equal(DefaultVersions))
@@ -38,7 +38,7 @@ var _ = Describe("NewImageStore", func() {
 			versions = `[{"openshift_version": "4.8", "cpu_architecture": "x86_64", "url": "http://example.com/image/48.iso", "rootfs_url": "http://example.com/image/48.img"}]`
 			Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
-			is, err := NewImageStore(nil, "")
+			is, err := NewImageStore(nil, "", false)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := []map[string]string{
@@ -56,7 +56,7 @@ var _ = Describe("NewImageStore", func() {
 			versions = "[]"
 			Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
-			_, err := NewImageStore(nil, "")
+			_, err := NewImageStore(nil, "", false)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("invalid versions: must not be empty"))
 
@@ -66,7 +66,7 @@ var _ = Describe("NewImageStore", func() {
 			versions = `[{"cpu_architecture": "x86_64", "url": "http://example.com/image/48.iso", "rootfs_url": "http://example.com/image/48.img"}]`
 			Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
-			_, err := NewImageStore(nil, "")
+			_, err := NewImageStore(nil, "", false)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -74,7 +74,7 @@ var _ = Describe("NewImageStore", func() {
 			versions = `[{"openshift_version": "4.8", "url": "http://example.com/image/48.iso", "rootfs_url": "http://example.com/image/48.img"}]`
 			Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
-			_, err := NewImageStore(nil, "")
+			_, err := NewImageStore(nil, "", false)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -82,7 +82,7 @@ var _ = Describe("NewImageStore", func() {
 			versions = `[{"openshift_version": "4.8", "cpu_architecture": "x86_64", "rootfs_url": "http://example.com/image/48.img"}]`
 			Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
-			_, err := NewImageStore(nil, "")
+			_, err := NewImageStore(nil, "", false)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -90,7 +90,7 @@ var _ = Describe("NewImageStore", func() {
 			versions = `[{"openshift_version": "4.8", "cpu_architecture": "x86_64", "url": "http://example.com/image/48.iso"}]`
 			Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
-			_, err := NewImageStore(nil, "")
+			_, err := NewImageStore(nil, "", false)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -144,7 +144,7 @@ var _ = Context("with a data directory configured", func() {
 				versions := fmt.Sprintf(versionsTemplate, ts.URL()+"/some.iso")
 				Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
-				is, err := NewImageStore(mockEditor, dataDir)
+				is, err := NewImageStore(mockEditor, dataDir, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "http://example.com/image/48.img", gomock.Any()).Return(nil)
@@ -165,7 +165,7 @@ var _ = Context("with a data directory configured", func() {
 				versions := fmt.Sprintf(versionsTemplate, ts.URL()+"/fail.iso")
 				Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
-				is, err := NewImageStore(mockEditor, dataDir)
+				is, err := NewImageStore(mockEditor, dataDir, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(is.Populate(ctx)).NotTo(Succeed())
 			})
@@ -180,7 +180,8 @@ var _ = Context("with a data directory configured", func() {
 				versions := fmt.Sprintf(versionsTemplate, ts.URL()+"/some.iso")
 				Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
-				is, err := NewImageStore(mockEditor, dataDir)
+				is, err := NewImageStore(mockEditor, dataDir, false)
+
 				Expect(err).NotTo(HaveOccurred())
 
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "http://example.com/image/48.img", gomock.Any()).Return(fmt.Errorf("minimal iso creation failed"))
@@ -197,7 +198,7 @@ var _ = Context("with a data directory configured", func() {
 				versions := fmt.Sprintf(versionsTemplate, ts.URL()+"/dontcallthis.iso")
 				Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
-				is, err := NewImageStore(mockEditor, dataDir)
+				is, err := NewImageStore(mockEditor, dataDir, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
 
@@ -215,7 +216,7 @@ var _ = Context("with a data directory configured", func() {
 				versions := fmt.Sprintf(versionsTemplate, ts.URL()+"/dontcallthis.iso")
 				Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 
-				is, err := NewImageStore(mockEditor, dataDir)
+				is, err := NewImageStore(mockEditor, dataDir, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-minimal-iso-4.8-x86_64.iso"), []byte("minimalisocontent"), 0600)).To(Succeed())
@@ -228,7 +229,7 @@ var _ = Context("with a data directory configured", func() {
 
 var _ = Describe("PathForParams", func() {
 	It("creates the correct path", func() {
-		is, err := NewImageStore(nil, "/tmp/some/dir")
+		is, err := NewImageStore(nil, "/tmp/some/dir", false)
 		Expect(err).NotTo(HaveOccurred())
 		expected := "/tmp/some/dir/rhcos-type-version-arch.iso"
 		Expect(is.PathForParams("type", "version", "arch")).To(Equal(expected))
@@ -257,7 +258,7 @@ var _ = Describe("HaveVersion", func() {
 	BeforeEach(func() {
 		Expect(os.Setenv("RHCOS_VERSIONS", versions)).To(Succeed())
 		var err error
-		store, err = NewImageStore(nil, "")
+		store, err = NewImageStore(nil, "", false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 	AfterEach(func() {


### PR DESCRIPTION
[Bug 2046521](https://bugzilla.redhat.com/show_bug.cgi?id=2046521): Allow disabling TLS verification
Cherry-picked from e61d9e7.
Original PR: https://github.com/openshift/assisted-image-service/pull/53

## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
Manual, see original [PR](https://github.com/openshift/assisted-image-service/pull/53)

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->

- https://github.com/openshift/assisted-image-service/pull/53

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
