### PR TITLE
NO-ISSUE: Update RHCOS pre-release x86_64 image URL

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -45,8 +45,8 @@ var (
 		{
 			"openshift_version": "pre-release",
 			"cpu_architecture":  "x86_64",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest/rhcos-live.x86_64.iso",
-			"rootfs_url":        "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest/rhcos-live-rootfs.x86_64.img",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.10.0-rc.0/rhcos-live.x86_64.iso",
+			"rootfs_url":        "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.10.0-rc.0/rhcos-live-rootfs.x86_64.img",
 			"version":           "x86_64-latest",
 		},
 		{


### PR DESCRIPTION
The images are currently not published in latest because of an
issue in the release process and makes our unit tests fail.

This is a workaround until the release process is fixed.
