### PR TITLE
Use fields from http.DefaultTransport in imagestore

### DIFF
--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -84,10 +84,13 @@ func NewImageStore(ed isoeditor.Editor, dataDir string, insecureSkipVerify bool,
 	if err := validateVersions(versions); err != nil {
 		return nil, err
 	}
-	transportConfig := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify}, //nolint:gosec // Optionally ignore TLS (G402 error)
+	transportConfig, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("expected http.DefaultTransport to be of type *http.Transport")
 	}
-	httpClient := &http.Client{Transport: transportConfig}
+	myTransport := transportConfig.Clone()
+	myTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecureSkipVerify} //nolint:gosec // Optionally ignore TLS (G402 error)
+	httpClient := &http.Client{Transport: myTransport}
 
 	return &rhcosStore{
 		versions:   versions,


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

http.DefaultTransport has some useful properties set that are not
present in a zero-value transport struct.

Specifically it sets up a function for fetching proxy environment
variables.

When we moved from using the default transport to creating our own to
solve https://bugzilla.redhat.com/show_bug.cgi?id=2034686 we also
removed the proxy environment variable handling as a side-effect.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

This was verified to fix the proxy issue in @chadcrum 's test environment.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @CrystalChun 
/cc @danielerez 

## Links
<!--
List any applicable links to related PRs or issues
-->

https://bugzilla.redhat.com/show_bug.cgi?id=2038903

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
