### PR TITLE
MGMT-9332: Add endpoint for rootfs and kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Downloads the RHCOS image for the specified image ID.
 
 - `Authorization`: this header is passed directly through to assisted service requests to handle RHSSO authentication
 
+### `GET /boot-artifacts/{artifact}`
+
+Downloads the artifact specified from the ISO.
+
+#### Query parameters
+
+- `version`: indicates the version of the RHCOS base image to use (must match an entry in `RHCOS_VERSIONS`)
+- `arch`: the base image cpu architecture (must match an entry in `RHCOS_VERSIONS`)
+
 ### `GET /health`
 
 Returns 503 until the images are downloaded

--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/openshift/assisted-image-service/internal/handlers"
 	"github.com/openshift/assisted-image-service/pkg/imagestore"
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
@@ -131,8 +130,7 @@ var _ = Describe("Image integration tests", func() {
 				}
 
 				// Set up image handler
-				reg := prometheus.NewRegistry()
-				handler := handlers.NewImageHandler(imageStore, reg, u.Scheme, u.Host, "", 1)
+				handler := handlers.NewImageHandler(imageStore, u.Scheme, u.Host, "", 1)
 				imageServer = httptest.NewServer(handler)
 				imageClient = imageServer.Client()
 			})

--- a/internal/handlers/boot_artifacts.go
+++ b/internal/handlers/boot_artifacts.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/openshift/assisted-image-service/pkg/imagestore"
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
@@ -39,9 +40,10 @@ func parseArtifact(path string) (string, error) {
 }
 
 func (b *BootArtifactsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
-		log.Error("Only GET method is supported with this endpoint.")
-		http.NotFound(w, r)
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		log.Error("Only GET and HEAD methods are supported with this endpoint.")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Header().Set("Allow", strings.Join([]string{http.MethodGet, http.MethodHead}, ", "))
 		return
 	}
 

--- a/internal/handlers/boot_artifacts.go
+++ b/internal/handlers/boot_artifacts.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/openshift/assisted-image-service/pkg/imagestore"
+	"github.com/openshift/assisted-image-service/pkg/isoeditor"
+	log "github.com/sirupsen/logrus"
+)
+
+type BootArtifactsHandler struct {
+	ImageStore imagestore.ImageStore
+}
+
+var _ http.Handler = &BootArtifactsHandler{}
+
+var bootpathRegexp = regexp.MustCompile(`^/boot-artifacts/(.+)`)
+
+func parseArtifact(path string) (string, error) {
+	match := bootpathRegexp.FindStringSubmatch(path)
+	if len(match) < 1 {
+		return "", fmt.Errorf("malformed download path: %s", path)
+	}
+
+	var artifact string
+	switch match[1] {
+	case "rootfs":
+		artifact = "rootfs.img"
+	case "kernel":
+		artifact = "vmlinuz"
+	default:
+		return "", fmt.Errorf("malformed download path: %s", path)
+	}
+	return artifact, nil
+}
+
+func (b *BootArtifactsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		log.Error("Only GET method is supported with this endpoint.")
+		http.NotFound(w, r)
+		return
+	}
+
+	artifact, err := parseArtifact(r.URL.Path)
+	if err != nil {
+		log.Errorf("failed to parse artifact: %v\n", err)
+		http.NotFound(w, r)
+		return
+	}
+	version, arch, err := b.parseQueryParams(r.URL.Query())
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_, err = w.Write([]byte(err.Error()))
+		if err != nil {
+			log.Errorf("Failed to write response: %v\n", err)
+		}
+		return
+	}
+
+	isoFileName := b.ImageStore.PathForParams(imagestore.ImageTypeFull, version, arch)
+	fileReader, err := isoeditor.GetFileFromISO(isoFileName, fmt.Sprintf("/images/pxeboot/%s", artifact))
+	if err != nil {
+		log.Errorf("Error creating file reader stream: %v\n", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer fileReader.Close()
+
+	modTime := time.Now()
+	fileInfo, err := os.Stat(isoFileName)
+	if err != nil {
+		log.Errorf("Error reading file info for %s", isoFileName)
+	} else {
+		modTime = fileInfo.ModTime()
+	}
+
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", artifact))
+	http.ServeContent(w, r, artifact, modTime, fileReader)
+}
+
+func (b *BootArtifactsHandler) parseQueryParams(values url.Values) (string, string, error) {
+	version := values.Get("version")
+	if version == "" {
+		return "", "", fmt.Errorf("'version' parameter required")
+	}
+	arch := values.Get("arch")
+	if arch == "" {
+		arch = defaultArch
+	}
+
+	return version, arch, nil
+}

--- a/internal/handlers/boot_artifacts.go
+++ b/internal/handlers/boot_artifacts.go
@@ -49,33 +49,34 @@ func (b *BootArtifactsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	artifact, err := parseArtifact(r.URL.Path)
 	if err != nil {
-		log.Errorf("failed to parse artifact: %v\n", err)
-		http.NotFound(w, r)
+		msg := fmt.Sprintf("Failed to parse artifact: %v", err)
+		log.Error(msg)
+		http.Error(w, msg, http.StatusNotFound)
 		return
 	}
 	version, arch, err := b.parseQueryParams(r.URL.Query())
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		_, err = w.Write([]byte(err.Error()))
-		if err != nil {
-			log.Errorf("Failed to write response: %v\n", err)
-		}
+		msg := fmt.Sprintf("Failed to parse query parameters: %v", err)
+		log.Error(msg)
+		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}
 
 	isoFileName := b.ImageStore.PathForParams(imagestore.ImageTypeFull, version, arch)
 	fileReader, err := isoeditor.GetFileFromISO(isoFileName, fmt.Sprintf("/images/pxeboot/%s", artifact))
 	if err != nil {
-		log.Errorf("Error creating file reader stream: %v\n", err)
-		w.WriteHeader(http.StatusInternalServerError)
+		msg := fmt.Sprintf("Error creating file reader stream: %v", err)
+		log.Error(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
 	defer fileReader.Close()
 
 	fileInfo, err := os.Stat(isoFileName)
 	if err != nil {
-		log.Errorf("Error reading file info for %s", isoFileName)
-		w.WriteHeader(http.StatusInternalServerError)
+		msg := fmt.Sprintf("Error reading file info for %s", isoFileName)
+		log.Error(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
 

--- a/internal/handlers/boot_artifacts_test.go
+++ b/internal/handlers/boot_artifacts_test.go
@@ -107,7 +107,7 @@ var _ = Describe("ServeHTTP", func() {
 			path := fmt.Sprintf("/boot-artifacts/%s?version=4.7", rootfsArtifact)
 			resp, err := client.Get(server.URL + path)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 		})
 
 		It("fails when no version is supplied", func() {

--- a/internal/handlers/boot_artifacts_test.go
+++ b/internal/handlers/boot_artifacts_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-image-service/internal/handlers"
+	"github.com/openshift/assisted-image-service/pkg/imagestore"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "handlers")
+}
+
+var _ = Describe("ServeHTTP", func() {
+	var (
+		ctrl              *gomock.Controller
+		mockImageStore    *imagestore.MockImageStore
+		server            *httptest.Server
+		client            *http.Client
+		fullImageFilename string
+		kernelArtifact    = "kernel"
+		rootfsArtifact    = "rootfs"
+		defaultArch       = "x86_64"
+	)
+
+	Context("with image files", func() {
+
+		mockISO := func(imageFileName string) string {
+			filesDir, err := os.MkdirTemp("", "isotest")
+			Expect(err).ToNot(HaveOccurred())
+
+			temp, err := os.CreateTemp("", imageFileName)
+			Expect(err).ToNot(HaveOccurred())
+
+			isoFile := temp.Name()
+			Expect(os.MkdirAll(filepath.Join(filesDir, "images/pxeboot"), 0755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(filesDir, "images/pxeboot/rootfs.img"), []byte("this is rootfs"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(filesDir, "images/pxeboot/vmlinuz"), []byte("this is kernel"), 0600)).To(Succeed())
+
+			cmd := exec.Command("genisoimage", "-rational-rock", "-J", "-joliet-long", "-o", isoFile, filesDir)
+			Expect(cmd.Run()).To(Succeed())
+			return isoFile
+		}
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			mockImageStore = imagestore.NewMockImageStore(ctrl)
+
+			fullImageFilename = mockISO("image_handler_test")
+			handler := &handlers.BootArtifactsHandler{
+				ImageStore: mockImageStore,
+			}
+			server = httptest.NewServer(handler)
+			client = server.Client()
+		})
+
+		AfterEach(func() {
+			os.Remove(fullImageFilename)
+			server.Close()
+		})
+
+		mockImage := func(version, imageType, arch string) {
+			mockImageStore.EXPECT().HaveVersion(version, arch).Return(true).AnyTimes()
+			imageFile := fullImageFilename
+			mockImageStore.EXPECT().PathForParams(imageType, version, arch).Return(imageFile).AnyTimes()
+		}
+
+		expectSuccessfulResponse := func(resp *http.Response, content []byte, artifact string) {
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Header.Get("Content-Disposition")).To(Equal(fmt.Sprintf("attachment; filename=%s", artifact)))
+			respContent, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(respContent).To(Equal(content))
+		}
+
+		It("returns a kernel artifact", func() {
+			mockImage("4.8", imagestore.ImageTypeFull, defaultArch)
+			path := fmt.Sprintf("/boot-artifacts/%s?version=4.8", kernelArtifact)
+			resp, err := client.Get(server.URL + path)
+			Expect(err).NotTo(HaveOccurred())
+			expectSuccessfulResponse(resp, []byte("this is kernel"), "vmlinuz")
+		})
+
+		It("uses the arch parameter", func() {
+			mockImage("4.8", imagestore.ImageTypeFull, "arm64")
+			path := fmt.Sprintf("/boot-artifacts/%s?version=4.8&arch=arm64", rootfsArtifact)
+			resp, err := client.Get(server.URL + path)
+			Expect(err).NotTo(HaveOccurred())
+			expectSuccessfulResponse(resp, []byte("this is rootfs"), "rootfs.img")
+		})
+
+		It("returns a rootfs artifact", func() {
+			mockImage("4.8", imagestore.ImageTypeFull, defaultArch)
+			path := fmt.Sprintf("/boot-artifacts/%s?version=4.8", rootfsArtifact)
+			resp, err := client.Get(server.URL + path)
+			Expect(err).NotTo(HaveOccurred())
+			expectSuccessfulResponse(resp, []byte("this is rootfs"), "rootfs.img")
+		})
+
+		It("fails for a non-existent version", func() {
+			mockImageStore.EXPECT().PathForParams(imagestore.ImageTypeFull, "4.7", defaultArch).Return("").AnyTimes()
+			mockImageStore.EXPECT().HaveVersion("4.7", defaultArch).Return(false)
+			path := fmt.Sprintf("/boot-artifacts/%s?version=4.7", rootfsArtifact)
+			resp, err := client.Get(server.URL + path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+		})
+
+		It("fails when no version is supplied", func() {
+			path := fmt.Sprintf("/boot-artifacts/%s", rootfsArtifact)
+			resp, err := client.Get(server.URL + path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("fails when no artifact is supplied", func() {
+			mockImageStore.EXPECT().HaveVersion("4.8", defaultArch).Return(true)
+			path := "/boot-artifacts/?version=4.8"
+			resp, err := client.Get(server.URL + path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("fails when non-existent artifact is supplied", func() {
+			resp, err := client.Get(server.URL + "/boot-artifacts/")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+	})
+})

--- a/internal/handlers/boot_artifacts_test.go
+++ b/internal/handlers/boot_artifacts_test.go
@@ -8,19 +8,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"testing"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/assisted-image-service/internal/handlers"
 	"github.com/openshift/assisted-image-service/pkg/imagestore"
 )
-
-func TestHandlers(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "handlers")
-}
 
 var _ = Describe("ServeHTTP", func() {
 	var (
@@ -58,7 +51,7 @@ var _ = Describe("ServeHTTP", func() {
 			mockImageStore = imagestore.NewMockImageStore(ctrl)
 
 			fullImageFilename = mockISO("image_handler_test")
-			handler := &handlers.BootArtifactsHandler{
+			handler := &BootArtifactsHandler{
 				ImageStore: mockImageStore,
 			}
 			server = httptest.NewServer(handler)

--- a/internal/handlers/boot_artifacts_test.go
+++ b/internal/handlers/boot_artifacts_test.go
@@ -32,6 +32,7 @@ var _ = Describe("ServeHTTP", func() {
 		mockISO := func(imageFileName string) string {
 			filesDir, err := os.MkdirTemp("", "isotest")
 			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(filesDir)
 
 			temp, err := os.CreateTemp("", imageFileName)
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/handlers/handlers_suite_test.go
+++ b/internal/handlers/handlers_suite_test.go
@@ -1,0 +1,13 @@
+package handlers
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "handlers")
+}

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"testing"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -18,11 +17,6 @@ import (
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 	"golang.org/x/sync/semaphore"
 )
-
-func TestHandlers(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "handlers")
-}
 
 var _ = Describe("ServeHTTP", func() {
 	var (

--- a/main.go
+++ b/main.go
@@ -13,6 +13,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
+	metrics "github.com/slok/go-http-metrics/metrics/prometheus"
+	"github.com/slok/go-http-metrics/middleware"
+	stdmiddleware "github.com/slok/go-http-metrics/middleware/std"
 )
 
 var Options struct {
@@ -69,20 +72,32 @@ func main() {
 	}()
 
 	reg := prometheus.NewRegistry()
-	imageHandler := handlers.NewImageHandler(is, reg, Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.HTTPSCAFile, Options.MaxConcurrentRequests)
+	metricsConfig := metrics.Config{
+		Registry:        reg,
+		Prefix:          "assisted_image_service",
+		DurationBuckets: []float64{.1, 1, 10, 50, 100, 300, 600},
+		SizeBuckets:     []float64{100, 1e6, 5e8, 1e9, 1e10},
+	}
+	mdw := middleware.New(middleware.Config{
+		Recorder: metrics.NewRecorder(metricsConfig),
+	})
+
+	imageHandler := handlers.NewImageHandler(is, Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.HTTPSCAFile, Options.MaxConcurrentRequests)
 	if Options.AllowedDomains != "" {
 		imageHandler = handlers.WithCORSMiddleware(imageHandler, Options.AllowedDomains)
 	}
 
-	bootArtifactsHandler := &handlers.BootArtifactsHandler{
-		ImageStore: is,
+	var bootArtifactsHandler http.Handler = &handlers.BootArtifactsHandler{ImageStore: is}
+	if Options.AllowedDomains != "" {
+		bootArtifactsHandler = handlers.WithCORSMiddleware(bootArtifactsHandler, Options.AllowedDomains)
 	}
 
-	http.Handle("/images/", imageHandler)
+	http.Handle("/images/", stdmiddleware.Handler("/images/:imageID", mdw, imageHandler))
+	http.Handle("/boot-artifacts/", stdmiddleware.Handler("", mdw, bootArtifactsHandler))
+
 	http.Handle("/health", readinessHandler)
 	http.Handle("/live", handlers.NewLivenessHandler())
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-	http.Handle("/boot-artifacts/", bootArtifactsHandler)
 
 	log.Info("Starting http handler...")
 	address := fmt.Sprintf(":%s", Options.ListenPort)

--- a/main.go
+++ b/main.go
@@ -74,10 +74,15 @@ func main() {
 		imageHandler = handlers.WithCORSMiddleware(imageHandler, Options.AllowedDomains)
 	}
 
+	bootArtifactsHandler := &handlers.BootArtifactsHandler{
+		ImageStore: is,
+	}
+
 	http.Handle("/images/", imageHandler)
 	http.Handle("/health", readinessHandler)
 	http.Handle("/live", handlers.NewLivenessHandler())
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	http.Handle("/boot-artifacts/", bootArtifactsHandler)
 
 	log.Info("Starting http handler...")
 	address := fmt.Sprintf(":%s", Options.ListenPort)

--- a/pkg/isoeditor/isoutil.go
+++ b/pkg/isoeditor/isoutil.go
@@ -246,3 +246,22 @@ func GetISOFileInfo(filePath, isoPath string) (int64, int64, error) {
 	defaultSectorSize := uint32(2 * 1024)
 	return int64(isoFile.Location() * defaultSectorSize), isoFile.Size(), nil
 }
+
+// Gets a readWrite seeker of a specific file from the ISO image
+func GetFileFromISO(isoPath, filePath string) (filesystem.File, error) {
+	d, err := diskfs.OpenWithMode(isoPath, diskfs.ReadOnly)
+	if err != nil {
+		return nil, err
+	}
+
+	fs, err := d.GetFilesystem(0)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := fs.OpenFile(filePath, os.O_RDONLY)
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

This PR adds a new endpoint to the image service
which will serve the rootfs or the kernel directly
from an ISO.

The new endpoint is of the form:
```
/boot-artifacts/{artifact-name}?{params}
```

For example:
```
/boot-artifacts/rootfs?version=4.9&arch=x86_64
/boot-artifacts/kernel?version=4.10&arch=arm64
```

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
Ran the image service locally and downloaded the rootfs and kernel using the new endpoints.
Ensured that they matched exactly the same files extracted from the iso using the `iso-read` command line tool.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mhrivnak 
/cc @danielerez 

## Links
<!--
List any applicable links to related PRs or issues
-->

Enhancement doc: https://github.com/openshift/assisted-service/pull/3389
JIRA: https://issues.redhat.com/browse/MGMT-9332

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
