### PR TITLE
Fix overlay reader for base readers that return EOF early

### DIFF
--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -143,7 +143,7 @@ func (or *overlayReader) Read(p []byte) (int, error) {
 
 	seekErr := or.seek(or.readIndex + int64(bytesRead))
 
-	if seekErr == nil || (readErr != nil && readErr != io.EOF) {
+	if readErr != nil && readErr != io.EOF {
 		return bytesRead, readErr
 	}
 	return bytesRead, seekErr


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

It's valid for a reader to return EOF at the same time as the last
bytes. If we have such a reader as the base for an overlay we return EOF
when the base reader returns EOF even if we haven't printed the overlay
yet.

This is specifically a problem for the append reader when we're always
getting to the end of the base before starting to read the overlay.


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

Unit and integration tests cover this

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @zaneb 
/cc @filanov 

## Links
<!--
List any applicable links to related PRs or issues
-->

https://issues.redhat.com/browse/MGMT-9333

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
