### PR TITLE
MGMT-9019: Download full ISO in parallel, but build the mionimal ISO sequentially

### DIFF
--- a/pkg/isoeditor/rhcos.go
+++ b/pkg/isoeditor/rhcos.go
@@ -28,7 +28,7 @@ func NewEditor(dataDir string) Editor {
 	return &rhcosEditor{workDir: dataDir}
 }
 
-// Creates the template minimal iso by removing the rootfs and adding the url
+// CreateMinimalISOTemplate Creates the template minimal iso by removing the rootfs and adding the url
 func (e *rhcosEditor) CreateMinimalISOTemplate(fullISOPath, rootFSURL, minimalISOPath string) error {
 	extractDir, err := os.MkdirTemp(e.workDir, "isoutil")
 	if err != nil {


### PR DESCRIPTION
## Description
In order to reduce the temporary space used to build the minimal ISO image, we don't want to extract all the images in parallel, then remove the `rootfs` and build it again. Instead, we'll download all the required images in parallel, as it is right now, and the build the images sequentially one by one, to reduce the space consumption. 

### Before the PR:
``` 
All in parallel:
Download ISO 1 ------- Download ISO 2 ------ Download ISO 3
         |                   |                       |
Build min ISO 1 --------- Build min ISO 2 ------ Build min ISO 3
```
### After the PR:
```
Download in parallel: 
Download ISO 1 ------- Download ISO 2 ------ Download ISO 3
Build sequentially: 
- Build min 1
- Build min 2
- Build min 3
```

## How was this code tested?
Monitoring the folder where the images are extracted and checking that there is no more than 1 extracted image at the same time

## Assignees
@mkowalski 

## Links
Internal ticketing system: [MGMT-9019](https://issues.redhat.com/browse/MGMT-9019)

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
