### PR TITLE
Return a 503 from images and boot-artifacts before downloads finish

### DIFF
--- a/internal/handlers/handlers_suite_test.go
+++ b/internal/handlers/handlers_suite_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -8,10 +9,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
 )
 
 func TestHandlers(t *testing.T) {
 	RegisterFailHandler(Fail)
+	log.SetOutput(io.Discard)
 	RunSpecs(t, "handlers")
 }
 

--- a/internal/handlers/readiness.go
+++ b/internal/handlers/readiness.go
@@ -17,11 +17,22 @@ func NewReadinessHandler() *ReadinessHandler {
 }
 
 func (a *ReadinessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ok := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }
+	a.runIfReady(http.HandlerFunc(ok), w, r)
+}
+
+func (a *ReadinessHandler) WithMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		a.runIfReady(next, w, r)
+	})
+}
+
+func (a *ReadinessHandler) runIfReady(next http.Handler, w http.ResponseWriter, r *http.Request) {
 	if !a.isEnabled {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
+	next.ServeHTTP(w, r)
 }
 
 func (a *ReadinessHandler) Enable() {

--- a/internal/handlers/readiness_test.go
+++ b/internal/handlers/readiness_test.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ServeHTTP", func() {
+	var (
+		handler *ReadinessHandler
+		server  *httptest.Server
+		client  *http.Client
+	)
+
+	BeforeEach(func() {
+		handler = NewReadinessHandler()
+		server = httptest.NewServer(handler)
+		client = server.Client()
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	It("returns 503 when not ready", func() {
+		resp, err := client.Get(fmt.Sprintf("%s/whatever", server.URL))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusServiceUnavailable))
+	})
+
+	It("returns 200 when ready", func() {
+		handler.Enable()
+		resp, err := client.Get(fmt.Sprintf("%s/whatever", server.URL))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	})
+})
+
+var _ = Describe("WithMiddleware", func() {
+	var (
+		handler *ReadinessHandler
+		server  *httptest.Server
+		client  *http.Client
+	)
+
+	teapot := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) })
+
+	BeforeEach(func() {
+		handler = NewReadinessHandler()
+		server = httptest.NewServer(handler.WithMiddleware(teapot))
+		client = server.Client()
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	It("returns 503 when not ready", func() {
+		resp, err := client.Get(fmt.Sprintf("%s/whatever", server.URL))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusServiceUnavailable))
+	})
+
+	It("returns 418 when ready", func() {
+		handler.Enable()
+		resp, err := client.Get(fmt.Sprintf("%s/whatever", server.URL))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusTeapot))
+	})
+})

--- a/main.go
+++ b/main.go
@@ -84,11 +84,13 @@ func main() {
 
 	asc := handlers.NewAssistedServiceClient(Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.HTTPSCAFile)
 	imageHandler := handlers.NewImageHandler(is, asc, Options.MaxConcurrentRequests, mdw)
+	imageHandler = readinessHandler.WithMiddleware(imageHandler)
 	if Options.AllowedDomains != "" {
 		imageHandler = handlers.WithCORSMiddleware(imageHandler, Options.AllowedDomains)
 	}
 
 	var bootArtifactsHandler http.Handler = &handlers.BootArtifactsHandler{ImageStore: is}
+	bootArtifactsHandler = readinessHandler.WithMiddleware(bootArtifactsHandler)
 	if Options.AllowedDomains != "" {
 		bootArtifactsHandler = handlers.WithCORSMiddleware(bootArtifactsHandler, Options.AllowedDomains)
 	}


### PR DESCRIPTION
## Description

This commit extends the readiness handler to provide a middleware that
will return 503s until we mark the handler ready. It will then call the
underlying handler.

This new middleware is applied to both the images and boot-artifacts
endpoints so it's more clear to a user that the failure it temporary
rather than some issue with the deployment or configuration.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

Deployed the service locally and tested responses from both the images and boot-artifacts endpoints before and after the template images were finished downloading.


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @CrystalChun 
/cc @filanov 

## Links
<!--
List any applicable links to related PRs or issues
-->
https://issues.redhat.com/browse/MGMT-9395

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
