### PR TITLE
MGMT-9538: Only log.Fatal from main in the image service

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -130,7 +130,9 @@ var _ = Describe("Image integration tests", func() {
 					)
 				}
 
-				asc := handlers.NewAssistedServiceClient(u.Scheme, u.Host, "")
+				asc, err := handlers.NewAssistedServiceClient(u.Scheme, u.Host, "")
+				Expect(err).NotTo(HaveOccurred())
+
 				mdw := middleware.New(middleware.Config{})
 				imageServer = httptest.NewServer(handlers.NewImageHandler(imageStore, asc, 1, mdw))
 				imageClient = imageServer.Client()

--- a/internal/handlers/assisted_service_client.go
+++ b/internal/handlers/assisted_service_client.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
-	log "github.com/sirupsen/logrus"
 )
 
 type AssistedServiceClient struct {
@@ -21,16 +20,16 @@ type AssistedServiceClient struct {
 
 const fileRouteFormat = "/api/assisted-install/v2/infra-envs/%s/downloads/files"
 
-func NewAssistedServiceClient(assistedServiceScheme, assistedServiceHost, caCertFile string) *AssistedServiceClient {
+func NewAssistedServiceClient(assistedServiceScheme, assistedServiceHost, caCertFile string) (*AssistedServiceClient, error) {
 	client := &http.Client{}
 	if caCertFile != "" {
 		caCert, err := ioutil.ReadFile(caCertFile)
 		if err != nil {
-			log.Fatalf("Error opening cert file %s, %s", caCertFile, err)
+			return nil, fmt.Errorf("failed to open cert file %s, %s", caCertFile, err)
 		}
 		caCertPool := x509.NewCertPool()
 		if !caCertPool.AppendCertsFromPEM(caCert) {
-			log.Fatalf("Failed to append cert %s, %s", caCertFile, err)
+			return nil, fmt.Errorf("failed to append cert %s, %s", caCertFile, err)
 		}
 
 		t := &http.Transport{
@@ -46,7 +45,7 @@ func NewAssistedServiceClient(assistedServiceScheme, assistedServiceHost, caCert
 		assistedServiceScheme: assistedServiceScheme,
 		assistedServiceHost:   assistedServiceHost,
 		client:                client,
-	}
+	}, nil
 }
 
 // ignitionContent returns the ramdisk data on success and the error and the corresponding http status code

--- a/internal/handlers/initrd_test.go
+++ b/internal/handlers/initrd_test.go
@@ -52,9 +52,12 @@ var _ = Describe("ServeHTTP", func() {
 		u, err := url.Parse(assistedServer.URL())
 		Expect(err).NotTo(HaveOccurred())
 
+		asc, err := NewAssistedServiceClient(u.Scheme, u.Host, "")
+		Expect(err).NotTo(HaveOccurred())
+
 		server = httptest.NewServer(&initrdHandler{
 			ImageStore: mockImageStore,
-			client:     NewAssistedServiceClient(u.Scheme, u.Host, ""),
+			client:     asc,
 		})
 
 		client = server.Client()

--- a/internal/handlers/iso_test.go
+++ b/internal/handlers/iso_test.go
@@ -109,10 +109,13 @@ var _ = Describe("ServeHTTP", func() {
 					return os.Open(isoPath)
 				}
 
+				asc, err := NewAssistedServiceClient(u.Scheme, u.Host, "")
+				Expect(err).NotTo(HaveOccurred())
+
 				handler := &isoHandler{
 					ImageStore:          mockImageStore,
 					GenerateImageStream: mockImageStream,
-					client:              NewAssistedServiceClient(u.Scheme, u.Host, ""),
+					client:              asc,
 				}
 				server = httptest.NewServer(handler)
 				client = server.Client()
@@ -215,10 +218,13 @@ var _ = Describe("ServeHTTP", func() {
 				return os.Open(isoPath)
 			}
 
+			asc, err := NewAssistedServiceClient(u.Scheme, u.Host, "")
+			Expect(err).NotTo(HaveOccurred())
+
 			handler := &isoHandler{
 				ImageStore:          mockImageStore,
 				GenerateImageStream: mockImageStream,
-				client:              NewAssistedServiceClient(u.Scheme, u.Host, ""),
+				client:              asc,
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()
@@ -252,10 +258,13 @@ var _ = Describe("ServeHTTP", func() {
 				return os.Open(isoPath)
 			}
 
+			asc, err := NewAssistedServiceClient(u.Scheme, u.Host, "")
+			Expect(err).NotTo(HaveOccurred())
+
 			handler := &isoHandler{
 				ImageStore:          mockImageStore,
 				GenerateImageStream: mockImageStream,
-				client:              NewAssistedServiceClient(u.Scheme, u.Host, ""),
+				client:              asc,
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()
@@ -286,10 +295,13 @@ var _ = Describe("ServeHTTP", func() {
 				return os.Open(isoPath)
 			}
 
+			asc, err := NewAssistedServiceClient(u.Scheme, u.Host, "")
+			Expect(err).NotTo(HaveOccurred())
+
 			handler := &isoHandler{
 				ImageStore:          mockImageStore,
 				GenerateImageStream: mockImageStream,
-				client:              NewAssistedServiceClient(u.Scheme, u.Host, ""),
+				client:              asc,
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()
@@ -313,9 +325,12 @@ var _ = Describe("ServeHTTP", func() {
 			u, err := url.Parse(assistedServer.URL())
 			Expect(err).NotTo(HaveOccurred())
 
+			asc, err := NewAssistedServiceClient(u.Scheme, u.Host, "")
+			Expect(err).NotTo(HaveOccurred())
+
 			handler := &isoHandler{
 				ImageStore: mockImageStore,
-				client:     NewAssistedServiceClient(u.Scheme, u.Host, ""),
+				client:     asc,
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()
@@ -345,9 +360,12 @@ var _ = Describe("ServeHTTP", func() {
 			u, err := url.Parse(assistedServer.URL())
 			Expect(err).NotTo(HaveOccurred())
 
+			asc, err := NewAssistedServiceClient(u.Scheme, u.Host, "")
+			Expect(err).NotTo(HaveOccurred())
+
 			handler := &isoHandler{
 				ImageStore: mockImageStore,
-				client:     NewAssistedServiceClient(u.Scheme, u.Host, ""),
+				client:     asc,
 			}
 			server := httptest.NewServer(handler)
 			defer server.Close()

--- a/main.go
+++ b/main.go
@@ -82,7 +82,11 @@ func main() {
 		Recorder: metrics.NewRecorder(metricsConfig),
 	})
 
-	asc := handlers.NewAssistedServiceClient(Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.HTTPSCAFile)
+	asc, err := handlers.NewAssistedServiceClient(Options.AssistedServiceScheme, Options.AssistedServiceHost, Options.HTTPSCAFile)
+	if err != nil {
+		log.Fatalf("Failed to create AssistedServiceClient: %v\n", err)
+	}
+
 	imageHandler := handlers.NewImageHandler(is, asc, Options.MaxConcurrentRequests, mdw)
 	imageHandler = readinessHandler.WithMiddleware(imageHandler)
 	if Options.AllowedDomains != "" {


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

This PR ensures that we use `log.Fatalf` only in the `main` function and not from internal or other package functions.


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
