### PR TITLE
Bug 2078531: add an option expose all endpoints on plain HTTP port

### DIFF
--- a/internal/servers/servers.go
+++ b/internal/servers/servers.go
@@ -1,0 +1,68 @@
+package servers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type ServerInfo struct {
+	HTTP          http.Server
+	HTTPS         http.Server
+	HTTPSKeyFile  string
+	HTTPSCertFile string
+}
+
+func Init(httpPort, httpsPort, HTTPSKeyFile, HTTPSCertFile string) *ServerInfo {
+	servers := ServerInfo{}
+	if httpsPort != "" && HTTPSKeyFile != "" && HTTPSCertFile != "" {
+		servers.HTTPS = http.Server{
+			Addr: fmt.Sprintf(":%s", httpsPort),
+		}
+		servers.HTTPSCertFile = HTTPSCertFile
+		servers.HTTPSKeyFile = HTTPSKeyFile
+		go servers.httpsListen()
+	}
+	if httpPort != "" {
+		servers.HTTP = http.Server{
+			Addr: fmt.Sprintf(":%s", httpPort),
+		}
+		go servers.httpListen()
+	}
+	return &servers
+}
+
+func shutdown(name string, server *http.Server) {
+	if err := server.Shutdown(context.TODO()); err != nil {
+		log.Infof("%s shutdown failed: %v", name, err)
+		if err := server.Close(); err != nil {
+			log.Fatalf("%s emergency shutdown failed: %v", name, err)
+		}
+	} else {
+		log.Infof("%s server terminated gracefully", name)
+	}
+}
+
+func (s *ServerInfo) Shutdown() bool {
+	if s.HTTPSKeyFile != "" && s.HTTPSCertFile != "" {
+		shutdown("HTTPS", &s.HTTPS)
+	}
+	shutdown("HTTP", &s.HTTP)
+	return true
+}
+
+func (s *ServerInfo) httpListen() {
+	log.Infof("Starting http handler on %s...", s.HTTP.Addr)
+	if err := s.HTTP.ListenAndServe(); err != http.ErrServerClosed {
+		log.Fatalf("HTTP listener closed: %v", err)
+	}
+}
+
+func (s *ServerInfo) httpsListen() {
+	log.Infof("Starting https handler on %s...", s.HTTPS.Addr)
+	if err := s.HTTPS.ListenAndServeTLS(s.HTTPSCertFile, s.HTTPSKeyFile); err != http.ErrServerClosed {
+		log.Fatalf("HTTPS listener closed: %v", err)
+	}
+}

--- a/internal/servers/servers_test.go
+++ b/internal/servers/servers_test.go
@@ -1,0 +1,129 @@
+package servers
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"io/ioutil"
+	"log"
+	"math/big"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var tmpDir string
+var httpsKeyFile, httpsCertFile *os.File
+
+var _ = BeforeSuite(func() {
+	var err error
+	// Generate self-signed key and cert
+	tmpDir, err = ioutil.TempDir("", "")
+	Expect(err).NotTo(HaveOccurred())
+	httpsKeyFile, err = ioutil.TempFile(tmpDir, "https.key")
+	Expect(err).NotTo(HaveOccurred())
+	httpsCertFile, err = ioutil.TempFile(tmpDir, "https.crt")
+	Expect(err).NotTo(HaveOccurred())
+
+	template := &x509.Certificate{
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		SubjectKeyId:          []byte{1, 2, 3},
+		SerialNumber:          big.NewInt(1234),
+		Subject: pkix.Name{
+			Country:      []string{"Earth"},
+			Organization: []string{"Yes"},
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(5, 5, 5),
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageCertSign,
+	}
+
+	privatekey, err := rsa.GenerateKey(rand.Reader, 2048)
+	Expect(err).NotTo(HaveOccurred())
+	var pemkey = &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privatekey)}
+	err = pem.Encode(httpsKeyFile, pemkey)
+	Expect(err).NotTo(HaveOccurred())
+
+	publickey := &privatekey.PublicKey
+	var parent = template
+	cert, err := x509.CreateCertificate(rand.Reader, template, parent, publickey, privatekey)
+	Expect(err).NotTo(HaveOccurred())
+	var pemcert = &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert}
+	err = pem.Encode(httpsCertFile, pemcert)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	Expect(os.RemoveAll(tmpDir)).To(Succeed())
+})
+
+var _ = Describe("HTTPListeners", func() {
+	It("starts http only server", func() {
+		listeners := Init("8080", "", "", "")
+
+		Expect(listeners.HTTP.Addr).To(Equal(":8080"))
+		Expect(listeners.HTTPS.Addr).To(Equal(""))
+
+		timeout := time.Second
+		_, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", "8080"), timeout)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listeners.Shutdown()).To(BeTrue())
+	})
+
+	It("starts http only server - no certs", func() {
+		listeners := Init("8081", "8443", "", "")
+
+		Expect(listeners.HTTP.Addr).To(Equal(":8081"))
+		Expect(listeners.HTTPS.Addr).To(Equal(""))
+
+		timeout := time.Second
+		_, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", "8081"), timeout)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listeners.Shutdown()).To(BeTrue())
+	})
+
+	It("starts https only server", func() {
+		listeners := Init("", "8443", httpsKeyFile.Name(), httpsCertFile.Name())
+
+		Expect(listeners.HTTP.Addr).To(Equal(""))
+		Expect(listeners.HTTPS.Addr).To(Equal(":8443"))
+
+		timeout := time.Second
+		_, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", "8443"), timeout)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listeners.Shutdown()).To(BeTrue())
+	})
+
+	It("starts both servers", func() {
+		listeners := Init("8082", "8444", httpsKeyFile.Name(), httpsCertFile.Name())
+
+		Expect(listeners.HTTP.Addr).To(Equal(":8082"))
+		Expect(listeners.HTTPS.Addr).To(Equal(":8444"))
+
+		timeout := time.Second
+		_, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", "8082"), timeout)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = net.DialTimeout("tcp", net.JoinHostPort("localhost", "8444"), timeout)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listeners.Shutdown()).To(BeTrue())
+	})
+})
+
+func TestServers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	log.SetOutput(io.Discard)
+	RunSpecs(t, "servers")
+}


### PR DESCRIPTION
## Description
IPXE flow requires artifacts to be available via HTTP. This change would ensure that if `LISTEN_HTTP_PORT` env var is set and HTTPS cert/key are set, the same endpoints are exposed on plain HTTP port as well

TODO:
* [x] Add a wrapper around http.Server and add unit tests

## How was this code tested?
local deployment


## Assignees
/cc @carbonin 
/cc @CrystalChun 
/cc @filanov 

## Checklist

- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
