### PR TITLE
hack: use `go install` to install goimports and mockgen

### DIFF
--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -2,4 +2,5 @@
 
 yum install -y install podman genisoimage && yum clean all
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
-go get -u golang.org/x/tools/cmd/goimports@v0.1.5 github.com/golang/mock/mockgen@v1.6.0
+GOFLAGS='' go install golang.org/x/tools/cmd/goimports@v0.1.5
+GOFLAGS='' go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
`go get` mutates go.mod/go.sum, so we should use "go install" to install additional tools.

This also unsets `GOFLAGS` when installing `goimports`/`mockgen` to avoid failing on CI as it has `-mod=vendor` set there by defaults