### PR TITLE
MGMT-10751: use boot-artifacts API as rootfs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ skipper make test
 - `HTTPS_CERT_FILE` - tls cert file path
 - `ASSISTED_SERVICE_SCHEME` - protocol to use to query assisted service for image information
 - `ASSISTED_SERVICE_HOST` - host or host:port to use to query assisted service for image information
+- `IMAGE_SERVICE_SCHEME` - protocol to use to query the image service
+- `IMAGE_SERVICE_HOST` - host or host:port to use to query the image service
 - `MAX_CONCURRENT_REQUESTS` - caps the number of inflight image downloads to avoid things like open file limits
 - `ALLOWED_DOMAINS` - When set, determines how the service responds to requests with `Origin` headers
 - `HTTP_LISTEN_PORT` - When set, plain http listener is started on that port

--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -65,8 +65,10 @@ var (
 		},
 	}
 
-	imageDir   string
-	imageStore imagestore.ImageStore
+	imageDir           string
+	imageStore         imagestore.ImageStore
+	imageServiceScheme = "http"
+	imageServiceHost   = "images.example.com"
 )
 
 var _ = Describe("Image integration tests", func() {
@@ -201,7 +203,7 @@ var _ = BeforeSuite(func() {
 	imageDir, err = ioutil.TempDir("", "imagesTest")
 	Expect(err).To(BeNil())
 
-	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir), imageDir, false, versions)
+	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir), imageDir, imageServiceScheme, imageServiceHost, false, versions)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = imageStore.Populate(context.Background())

--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ var Options struct {
 	OSImages              string `envconfig:"OS_IMAGES"`
 	AllowedDomains        string `envconfig:"ALLOWED_DOMAINS"`
 	InsecureSkipVerify    bool   `envconfig:"INSECURE_SKIP_VERIFY" default:"false"`
+	ImageServiceScheme    string `envconfig:"IMAGE_SERVICE_SCHEME"`
+	ImageServiceHost      string `envconfig:"IMAGE_SERVICE_HOST"`
 }
 
 func main() {
@@ -60,7 +62,7 @@ func main() {
 		}
 	}
 
-	is, err := imagestore.NewImageStore(isoeditor.NewEditor(Options.DataDir), Options.DataDir, Options.InsecureSkipVerify, versions)
+	is, err := imagestore.NewImageStore(isoeditor.NewEditor(Options.DataDir), Options.DataDir, Options.ImageServiceScheme, Options.ImageServiceHost, Options.InsecureSkipVerify, versions)
 	if err != nil {
 		log.Fatalf("Failed to create image store: %v\n", err)
 	}


### PR DESCRIPTION
## Description

When creating a minimal ISO template the rootfsURL is injected to grub config files.
For each OS image metadata (OS_IMAGES) the rootfs_url is available as an external URL to the img file.
This URL is currently used on imagestore -> Populate.

This change is removing the requirement to specify an external rootfs URL for each image, instead, we're now using the
/boot-artifacts/rootfs API. I.e. a URL as follows is generated when creating the minimal ISO and injected to the grub configs:
http://`<image-service-base-url>`/boot-artifacts/rootfs?arch=x86_64&version=4.10

Hence, when deploying the image service, IMAGE_SERVICE_BASE_URL env var should be now specified.

Note: the previous behaviour of using the rootfs_url from OS_IMAGES is kept as a fallback for now. Can be removed later on once ensuring IMAGE_SERVICE_BASE_URL is available for the deployment.


## How was this code tested?
Tested minimal ISO functionality manually and modified/added relevant unit tests.

## Assignees
/cc @carbonin 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
