### PR TITLE
NO-ISSUE: bump golang to 1.17

### DIFF
--- a/Dockerfile.image-service
+++ b/Dockerfile.image-service
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
 
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/Dockerfile.image-service-build
+++ b/Dockerfile.image-service-build
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16
+FROM registry.ci.openshift.org/openshift/release:golang-1.17
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/assisted-image-service
 
-go 1.16
+go 1.17
 
 require (
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e
@@ -18,4 +18,26 @@ require (
 	github.com/slok/go-http-metrics v0.9.0
 	github.com/thoas/go-funk v0.9.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pierrec/lz4 v2.3.0+incompatible // indirect
+	github.com/pkg/xattr v0.4.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.32.1 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/ulikunitz/xz v0.5.10 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/djherbis/times.v1 v1.2.0 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
## Description

Updated golang in:
* go.mod: go 1.16 -> go 1.17
* bump openshift/release to golang-1.17 in Dockerfile

Address issues discovered in:
- https://github.com/stolostron/backlog/issues/23440
- https://github.com/stolostron/backlog/issues/23369
- https://github.com/stolostron/backlog/issues/23297

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
Invoked tests locally and waiting for CI to do a full run

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
