### PR TITLE
MGMT-11048: add image_service_host var to template

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -77,6 +77,9 @@ parameters:
   value: 15Gi
 - name: REPLICAS_COUNT
   value: "3"
+- name: IMAGE_SERVICE_BASE_URL
+  value: ''
+  required: true
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -123,6 +126,8 @@ objects:
             value: http
           - name: ASSISTED_SERVICE_HOST
             value: "assisted-service:8090"
+          - name: IMAGE_SERVICE_HOST
+            value: ${IMAGE_SERVICE_BASE_URL}
           - name: DATA_DIR
             value: "/data"
           ports:


### PR DESCRIPTION
## Description
* As the service CRD for SaaS deployment is in the template, added IMAGE_SERVICE_HOST env var.
* As we can't fetch the external url of the image-service, Set IMAGE_SERVICE_HOST by IMAGE_SERVICE_BASE_URL env var.
* In buildRootfsURL, added support for a host string that contains scheme and path.

## How was this code tested?
Added relevant unit-tests.

## Assignees
/cc @carbonin 

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
