### PR TITLE
Remove OCP 4.6 from integration environment

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -9,13 +9,6 @@ parameters:
   value: |
     [
       {
-        "openshift_version": "4.6",
-        "cpu_architecture": "x86_64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso",
-        "rootfs_url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img",
-        "version": "46.82.202012051820-0"
-      },
-      {
         "openshift_version": "4.7",
         "cpu_architecture": "x86_64",
         "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.7/4.7.33/rhcos-4.7.33-x86_64-live.x86_64.iso",

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -21,13 +21,6 @@ import (
 
 var DefaultVersions = []map[string]string{
 	{
-		"openshift_version": "4.6",
-		"cpu_architecture":  "x86_64",
-		"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso",
-		"rootfs_url":        "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img",
-		"version":           "46.82.202012051820-0",
-	},
-	{
 		"openshift_version": "4.7",
 		"cpu_architecture":  "x86_64",
 		"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.7/4.7.33/rhcos-4.7.33-x86_64-live.x86_64.iso",


### PR DESCRIPTION
## Description

There's currently no usage of OCP 4.6 in SaaS prod, so we can clean up this version from all our environments.

## How was this code tested?

No tests needed

## Assignees

/cc @gamli75 
/cc @danielerez 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
