### PR TITLE
MGMT-11618: remove OCP 4.7 from integration env

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -9,12 +9,6 @@ parameters:
   value: |
     [
       {
-        "openshift_version": "4.7",
-        "cpu_architecture": "x86_64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.7/4.7.33/rhcos-4.7.33-x86_64-live.x86_64.iso",
-        "version": "47.84.202109241831-0"
-      },
-      {
         "openshift_version": "4.8",
         "cpu_architecture": "x86_64",
         "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso",

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -20,12 +20,6 @@ import (
 
 var DefaultVersions = []map[string]string{
 	{
-		"openshift_version": "4.7",
-		"cpu_architecture":  "x86_64",
-		"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.7/4.7.33/rhcos-4.7.33-x86_64-live.x86_64.iso",
-		"version":           "47.84.202109241831-0",
-	},
-	{
 		"openshift_version": "4.8",
 		"cpu_architecture":  "x86_64",
 		"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso",


### PR DESCRIPTION
## Description
It is unused on prod SaaS, so there's no need for us to download a redundant ISO image in our tests.

## How was this code tested?
No test needed

## Assignees

## Links
https://issues.redhat.com/browse/MGMT-11618


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
