### PR TITLE
MGMT-11442: Fetch discovery ignition with static networking if minimal iso requested.

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -111,9 +111,10 @@ var _ = Describe("Image integration tests", func() {
 				assistedServer = ghttp.NewServer()
 				u, err := url.Parse(assistedServer.URL())
 				Expect(err).NotTo(HaveOccurred())
+				queryString := fmt.Sprintf("file_name=discovery.ign&discovery_iso_type=%s", tc.imageType)
 				assistedServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/downloads/files", imageID), "file_name=discovery.ign"),
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/downloads/files", imageID), queryString),
 						ghttp.RespondWith(http.StatusOK, tc.expectedIgnition),
 					),
 				)

--- a/internal/handlers/assisted_service_client.go
+++ b/internal/handlers/assisted_service_client.go
@@ -91,7 +91,7 @@ func (c *AssistedServiceClient) ramdiskContent(imageServiceRequest *http.Request
 // ignitionContent returns the ignition data on success and the error and the corresponding http status code
 // The code is also returned to ensure issues with authentication from the assisted service request are communicated back to the image service user
 // The returned code should only be used if an error is also returned
-func (c *AssistedServiceClient) ignitionContent(imageServiceRequest *http.Request, imageID string) (*isoeditor.IgnitionContent, string, int, error) {
+func (c *AssistedServiceClient) ignitionContent(imageServiceRequest *http.Request, imageID string, imageType string) (*isoeditor.IgnitionContent, string, int, error) {
 	if c.assistedServiceHost == "" {
 		return nil, "", 0, nil
 	}
@@ -103,6 +103,9 @@ func (c *AssistedServiceClient) ignitionContent(imageServiceRequest *http.Reques
 	}
 	queryValues := url.Values{}
 	queryValues.Set("file_name", "discovery.ign")
+	if imageType != "" {
+		queryValues.Set("discovery_iso_type", imageType)
+	}
 	u.RawQuery = queryValues.Encode()
 
 	req, err := http.NewRequestWithContext(imageServiceRequest.Context(), "GET", u.String(), nil)

--- a/internal/handlers/initrd.go
+++ b/internal/handlers/initrd.go
@@ -48,7 +48,7 @@ func (h *initrdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ignition, lastModified, code, err := h.client.ignitionContent(r, imageID)
+	ignition, lastModified, code, err := h.client.ignitionContent(r, imageID, "")
 	if err != nil {
 		httpErrorf(w, code, "Error retrieving ignition content: %v", err)
 		return

--- a/internal/handlers/iso.go
+++ b/internal/handlers/iso.go
@@ -44,7 +44,7 @@ func (h *isoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ignition, lastModified, statusCode, err := h.client.ignitionContent(r, imageID)
+	ignition, lastModified, statusCode, err := h.client.ignitionContent(r, imageID, params.imageType)
 	if err != nil {
 		log.Errorf("Error retrieving ignition content: %v\n", err)
 		w.WriteHeader(statusCode)


### PR DESCRIPTION
This will make a request to the assisted-service, passing the value of the request parameter "imageType"
When the PR https://github.com/openshift/assisted-service/pull/4309 is merged then the assisted service will respond by
including static networking config in the discovery ignition when a minimal iso is requested.

The static networking config will not be included in the ignition if a full iso is requested.

## How was this code tested?
This code is covered by modification of unit tests to cover the functionality.

## Assignees

/cc @carbonin 
/cc @nmagnezi 

## Links


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
