### PR TITLE
NO-ISSUE: Performance enhancements for unit tests

### DIFF
--- a/pkg/servers/servers.go
+++ b/pkg/servers/servers.go
@@ -14,6 +14,7 @@ type ServerInfo struct {
 	HTTPSKeyFile    string
 	HTTPSCertFile   string
 	HasBothHandlers bool
+	FastShutdown    bool
 }
 
 func New(httpPort, httpsPort, HTTPSKeyFile, HTTPSCertFile string) *ServerInfo {
@@ -58,6 +59,7 @@ func (s *ServerInfo) ListenAndServe() {
 	if s.HTTP != nil {
 		go s.httpListen()
 	}
+
 	if s.HTTPS != nil {
 		go s.httpsListen()
 	}
@@ -65,10 +67,18 @@ func (s *ServerInfo) ListenAndServe() {
 
 func (s *ServerInfo) Shutdown() bool {
 	if s.HTTPS != nil {
-		shutdown("HTTPS", s.HTTPS)
+		if s.FastShutdown {
+			s.HTTPS.Close()
+		} else {
+			shutdown("HTTPS", s.HTTPS)
+		}
 	}
 	if s.HTTP != nil {
-		shutdown("HTTP", s.HTTP)
+		if s.FastShutdown {
+			s.HTTP.Close()
+		} else {
+			shutdown("HTTP", s.HTTP)
+		}
 	}
 	return true
 }


### PR DESCRIPTION
## Description
When running unit tests locally, I ran into a couple of issues

1: The tests would have frequent connection failures when trying to create http servers on various ports, this felt like a bug, but would not consistently happen for all users.
2: The unit tests would take a long time to "clean up" adding a lot of uneccesary overhead to tests.

This commit makes sure that when we launch a HTTP or HTTPS server that we wait a reasonable amount of time for them to come online before exiting the non-blocking ListenAndServe() method.
We also added a "Fast shutdown" mode to the HTTP and HTTPS servers where the connection will be closed instead of shut down. This is exclusively for use in testing environments and should not be used in production.


## How was this code tested?
By running the unit tests

## Assignees

/cc @carbonin 
/cc @nmagnezi 



## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
