### PR TITLE
MGMT-12054: Support discovery kernel arguments for full-iso and minimal-iso

### DIFF
--- a/internal/handlers/iso.go
+++ b/internal/handlers/iso.go
@@ -61,7 +61,15 @@ func (h *isoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	isoReader, err := h.GenerateImageStream(h.ImageStore.PathForParams(params.imageType, params.version, params.arch), ignition, ramdisk)
+	var kargs []byte
+	kargs, statusCode, err = h.client.discoveryKernelArguments(r, imageID)
+	if err != nil {
+		log.Errorf("Error retrieving kernel arguments content: %v\n", err)
+		w.WriteHeader(statusCode)
+		return
+	}
+
+	isoReader, err := h.GenerateImageStream(h.ImageStore.PathForParams(params.imageType, params.version, params.arch), ignition, ramdisk, kargs)
 	if err != nil {
 		log.Errorf("Error creating image stream: %v\n", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/isoeditor/isoeditor_suite_test.go
+++ b/pkg/isoeditor/isoeditor_suite_test.go
@@ -18,6 +18,7 @@ func TestIsoEditor(t *testing.T) {
 const testGrubConfig = `
 menuentry 'RHEL CoreOS (Live)' --class fedora --class gnu-linux --class gnu --class os {
 	linux /images/pxeboot/vmlinuz random.trust_cpu=on rd.luks.options=discard coreos.liveiso=rhcos-46.82.202010091720-0 ignition.firstboot ignition.platform.id=metal
+###################### COREOS_KARG_EMBED_AREA
 	initrd /images/pxeboot/initrd.img /images/ignition.img
 }
 `
@@ -28,6 +29,7 @@ label linux
   menu default
   kernel /images/pxeboot/vmlinuz
   append initrd=/images/pxeboot/initrd.img,/images/ignition.img random.trust_cpu=on rd.luks.options=discard coreos.liveiso=rhcos-46.82.202010091720-0 ignition.firstboot ignition.platform.id=metal
+###################### COREOS_KARG_EMBED_AREA
 `
 
 const ignitionPaddingLength = 256 * 1024 // 256KB

--- a/pkg/isoeditor/isoutil.go
+++ b/pkg/isoeditor/isoutil.go
@@ -242,6 +242,7 @@ func GetISOFileInfo(filePath, isoPath string) (int64, int64, error) {
 		return 0, 0, errors.Wrapf(err, "Failed to open file %s", filePath)
 	}
 
+	defer fsFile.Close()
 	isoFile := fsFile.(*iso9660.File)
 	defaultSectorSize := uint32(2 * 1024)
 	return int64(isoFile.Location() * defaultSectorSize), isoFile.Size(), nil
@@ -264,4 +265,18 @@ func GetFileFromISO(isoPath, filePath string) (filesystem.File, error) {
 		return nil, err
 	}
 	return file, nil
+}
+
+// Reads a whole specific file from the ISO image
+func ReadFileFromISO(isoPath, filePath string) ([]byte, error) {
+	f, err := GetFileFromISO(isoPath, filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	ret, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
 }

--- a/pkg/isoeditor/kargs.go
+++ b/pkg/isoeditor/kargs.go
@@ -1,0 +1,123 @@
+package isoeditor
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+
+	"github.com/openshift/assisted-image-service/pkg/overlay"
+)
+
+const (
+	defaultGrubFilePath     = "/EFI/redhat/grub.cfg"
+	defaultIsolinuxFilePath = "/isolinux/isolinux.cfg"
+	kargsConfigFilePath     = "/coreos/kargs.json"
+)
+
+type FileReader func(isoPath, filePath string) ([]byte, error)
+
+func kargsFiles(isoPath string, fileReader FileReader) ([]string, error) {
+	kargsData, err := fileReader(isoPath, kargsConfigFilePath)
+	if err != nil {
+		// If the kargs file is not found, it is probably iso for old iso version which the file does not exist.  Therefore,
+		// default is returned
+		return []string{defaultGrubFilePath, defaultIsolinuxFilePath}, nil
+	}
+	var kargsConfig struct {
+		Files []struct {
+			Path *string
+		}
+	}
+	if err := json.Unmarshal(kargsData, &kargsConfig); err != nil {
+		return nil, err
+	}
+	var ret []string
+	for _, file := range kargsConfig.Files {
+		if file.Path != nil {
+			ret = append(ret, *file.Path)
+		}
+	}
+	return ret, nil
+}
+
+func KargsFiles(isoPath string) ([]string, error) {
+	return kargsFiles(isoPath, ReadFileFromISO)
+}
+
+func kargsEmbedAreaBoundariesFinder(isoPath, filePath string, fileBoundariesFinder BoundariesFinder, fileReader FileReader) (int64, int64, error) {
+	start, _, err := fileBoundariesFinder(filePath, isoPath)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	b, err := fileReader(isoPath, filePath)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	re := regexp.MustCompile(`(\n#*)# COREOS_KARG_EMBED_AREA`)
+	submatchIndexes := re.FindSubmatchIndex(b)
+	if len(submatchIndexes) != 4 {
+		return 0, 0, errors.New("failed to find COREOS_KARG_EMBED_AREA")
+	}
+	return start + int64(submatchIndexes[2]), int64(submatchIndexes[3] - submatchIndexes[2]), nil
+}
+
+func createKargsEmbedAreaBoundariesFinder() BoundariesFinder {
+	return func(filePath, isoPath string) (int64, int64, error) {
+		return kargsEmbedAreaBoundariesFinder(isoPath, filePath, GetISOFileInfo, ReadFileFromISO)
+	}
+}
+
+func readerForKargsContent(isoPath string, filePath string, base io.ReadSeeker, contentReader *bytes.Reader) (overlay.OverlayReader, error) {
+	return readerForContent(isoPath, filePath, base, contentReader, createKargsEmbedAreaBoundariesFinder())
+}
+
+type kernelArgument struct {
+	// The operation to apply on the kernel argument.
+	// Enum: [append replace delete]
+	Operation string `json:"operation,omitempty"`
+
+	// Kernel argument can have the form <parameter> or <parameter>=<value>. The following examples should
+	// be supported:
+	// rd.net.timeout.carrier=60
+	// isolcpus=1,2,10-20,100-2000:2/25
+	// quiet
+	// The parsing by the command line parser in linux kernel is much looser and this pattern follows it.
+	Value string `json:"value,omitempty"`
+}
+
+type kernelArguments []*kernelArgument
+
+func KargsToStr(args []string) (string, error) {
+	var kargs kernelArguments
+	for _, s := range args {
+		kargs = append(kargs, &kernelArgument{
+			Operation: "append",
+			Value:     s,
+		})
+	}
+	b, err := json.Marshal(&kargs)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal kernel arguments %v", err)
+	}
+	return string(b), nil
+}
+
+func StrToKargs(kargsStr string) ([]string, error) {
+	var kargs kernelArguments
+	if err := json.Unmarshal([]byte(kargsStr), &kargs); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal kernel arguments %v", err)
+	}
+	var args []string
+	for _, arg := range kargs {
+		if arg.Operation != "append" {
+			return nil, fmt.Errorf("only 'append' operation is allowed.  got %s", arg.Operation)
+		}
+		args = append(args, arg.Value)
+	}
+	return args, nil
+}

--- a/pkg/isoeditor/kargs_test.go
+++ b/pkg/isoeditor/kargs_test.go
@@ -1,0 +1,134 @@
+package isoeditor
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Context("kargs tests", func() {
+
+	const (
+		kargsConfileFile = `
+{
+  "default": "mitigations=auto,nosmt coreos.liveiso=fedora-coreos-35.20220103.3.0 ignition.firstboot ignition.platform.id=metal",
+  "files": [
+    {
+      "offset": 970,
+      "path": "EFI/fedora/grub.cfg"
+    },
+    {
+      "offset": 1870,
+      "path": "isolinux/isolinux.cfg"
+    }
+  ],
+  "size": 1137
+}
+`
+		grubFileWithEmbedArea = `
+function load_video {
+  insmod efi_gop
+}
+
+insmod ext2
+
+set timeout=5
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Fedora CoreOS (Live)' --class fedora --class gnu-linux --class gnu --class os {
+	linux /images/pxeboot/vmlinuz mitigations=auto,nosmt coreos.liveiso=fedora-coreos-35.20220103.3.0 ignition.firstboot ignition.platform.id=metal
+################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################ COREOS_KARG_EMBED_AREA
+	initrd /images/pxeboot/initrd.img /images/ignition.img
+}
+`
+		grubFileWithoutEmbedArea = `
+function load_video {
+  insmod efi_gop
+}
+
+insmod ext2
+
+set timeout=5
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Fedora CoreOS (Live)' --class fedora --class gnu-linux --class gnu --class os {
+	linux /images/pxeboot/vmlinuz mitigations=auto,nosmt coreos.liveiso=fedora-coreos-35.20220103.3.0 ignition.firstboot ignition.platform.id=metal
+	initrd /images/pxeboot/initrd.img /images/ignition.img
+}
+`
+	)
+
+	mockFileReaderCreator := func(ret []byte, err error) FileReader {
+		return func(_, _ string) ([]byte, error) {
+			return ret, err
+		}
+	}
+	mockFileReaderSuccess := func(fileData string) FileReader {
+		return mockFileReaderCreator([]byte(fileData), nil)
+	}
+	mockFileReaderFailure := func() FileReader {
+		return mockFileReaderCreator(nil, errors.New("this is an error"))
+	}
+
+	mockBoundariesFinderCreator := func(start, length int64, err error) BoundariesFinder {
+		return func(_, _ string) (int64, int64, error) {
+			return start, length, err
+		}
+	}
+
+	mockBoundariesFinderSuccess := func(start, length int64) BoundariesFinder {
+		return mockBoundariesFinderCreator(start, length, nil)
+	}
+
+	mockBoundariesFinderFailure := func() BoundariesFinder {
+		return mockBoundariesFinderCreator(0, 0, errors.New("this is an error"))
+	}
+
+	Describe("kargsFiles", func() {
+		It("fails to read kargs file", func() {
+			files, err := kargsFiles("isoPath", mockFileReaderFailure())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(files).To(Equal([]string{defaultGrubFilePath, defaultIsolinuxFilePath}))
+		})
+		It("kargs file is malformed", func() {
+			files, err := kargsFiles("isoPath", mockFileReaderSuccess("malformedData"))
+			Expect(err).To(HaveOccurred())
+			Expect(files).To(BeNil())
+		})
+		It("empty kargs file", func() {
+			fileData := `{"files": []}`
+			files, err := kargsFiles("isoPath", mockFileReaderSuccess(fileData))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(files).To(HaveLen(0))
+		})
+		It("non empty kargs file", func() {
+			files, err := kargsFiles("isoPath", mockFileReaderSuccess(kargsConfileFile))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(files).To(Equal([]string{"EFI/fedora/grub.cfg", "isolinux/isolinux.cfg"}))
+		})
+	})
+	Describe("kargsEmbedAreaBoundariesFinder", func() {
+		It("fail finding file boundaries", func() {
+			_, _, err := kargsEmbedAreaBoundariesFinder("isoPath", "filePath", mockBoundariesFinderFailure(), mockFileReaderSuccess(grubFileWithEmbedArea))
+			Expect(err).To(HaveOccurred())
+		})
+		It("fail reading file", func() {
+			_, _, err := kargsEmbedAreaBoundariesFinder("isoPath", "filePath", mockBoundariesFinderSuccess(100, 100), mockFileReaderFailure())
+			Expect(err).To(HaveOccurred())
+		})
+		It("no embed area found", func() {
+			_, _, err := kargsEmbedAreaBoundariesFinder("isoPath", "filePath", mockBoundariesFinderSuccess(100, 100), mockFileReaderSuccess(grubFileWithoutEmbedArea))
+			Expect(err).To(HaveOccurred())
+		})
+		It("embed area found", func() {
+			start, length, err := kargsEmbedAreaBoundariesFinder("isoPath", "filePath", mockBoundariesFinderSuccess(1000, int64(len(grubFileWithEmbedArea))),
+				mockFileReaderSuccess(grubFileWithEmbedArea))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(start).To(Equal(int64(1375)))
+			Expect(length).To(Equal(int64(1024)))
+		})
+	})
+})

--- a/pkg/isoeditor/stream.go
+++ b/pkg/isoeditor/stream.go
@@ -14,9 +14,11 @@ const ignitionImagePath = "/images/ignition.img"
 
 type ImageReader = overlay.OverlayReader
 
-type StreamGeneratorFunc func(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (ImageReader, error)
+type BoundariesFinder func(filePath, isoPath string) (int64, int64, error)
 
-func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (ImageReader, error) {
+type StreamGeneratorFunc func(isoPath string, ignitionContent *IgnitionContent, ramdiskContent, kargs []byte) (ImageReader, error)
+
+func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte, kargs []byte) (ImageReader, error) {
 	isoReader, err := os.Open(isoPath)
 	if err != nil {
 		return nil, err
@@ -27,23 +29,36 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 		return nil, err
 	}
 
-	r, err := readerForContent(isoPath, ignitionImagePath, isoReader, ignitionReader)
+	r, err := readerForFileContent(isoPath, ignitionImagePath, isoReader, ignitionReader)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create overwrite reader for ignition")
 	}
 
 	if ramdiskContent != nil {
-		r, err = readerForContent(isoPath, ramDiskImagePath, r, bytes.NewReader(ramdiskContent))
+		r, err = readerForFileContent(isoPath, ramDiskImagePath, r, bytes.NewReader(ramdiskContent))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create overwrite reader for ramdisk")
+		}
+	}
+
+	if kargs != nil {
+		files, err := KargsFiles(isoPath)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read files to patch for kernel arguments")
+		}
+		for _, file := range files {
+			r, err = readerForKargsContent(isoPath, file, r, bytes.NewReader(kargs))
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to create overwrite reader for kernel arguments in file \"%s\"", file)
+			}
 		}
 	}
 
 	return r, nil
 }
 
-func readerForContent(isoPath string, filePath string, base io.ReadSeeker, contentReader *bytes.Reader) (overlay.OverlayReader, error) {
-	start, length, err := GetISOFileInfo(filePath, isoPath)
+func readerForContent(isoPath, filePath string, base io.ReadSeeker, contentReader *bytes.Reader, boundariesFinder BoundariesFinder) (overlay.OverlayReader, error) {
+	start, length, err := boundariesFinder(filePath, isoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -63,4 +78,8 @@ func readerForContent(isoPath string, filePath string, base io.ReadSeeker, conte
 	}
 
 	return r, nil
+}
+
+func readerForFileContent(isoPath string, filePath string, base io.ReadSeeker, contentReader *bytes.Reader) (overlay.OverlayReader, error) {
+	return readerForContent(isoPath, filePath, base, contentReader, GetISOFileInfo)
 }


### PR DESCRIPTION

When streaming the discovery ISO file, the kernel arguments are included as part of some files: grub.cfg and isolinux.cfg

Each of these files contains an area where the kernel arguments can be embedded. This are can be identified by the regex "(\n#+) COREOS_KARG_EMBED_AREA". The arguments should overwrite this are from the beginning and should not pass the last # (hash sign). To do that, an overlay was created.

In new Openshift versions, there is a file that contains the file names, while in old versions the file does not exist. If the file exists, the files to embed the kernel arguments are taken from this config file. Otherwise, the default files [/EFI/redhat/grub.cfg, /isolinux/isolinux.cfg] are used.

## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @filanov 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
