### PR TITLE
removes openssl-libs update for CVE-2022-0778

### DIFF
--- a/Dockerfile.image-service
+++ b/Dockerfile.image-service
@@ -8,10 +8,6 @@ RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /assisted-image-service 
 
 FROM quay.io/centos/centos:stream8
 
-# Force an update to fix CVE-2022-0778
-# This can be removed when the base image is updated
-RUN dnf update -y openssl-libs
-
 ARG DATA_DIR=/data
 RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR
 VOLUME $DATA_DIR


### PR DESCRIPTION
## Description

The latest image includes the updated openssl-libs package:

```
$ podman run --pull=always -it --rm quay.io/centos/centos:stream8 rpm -q --changelog openssl-libs 2>/dev/null | grep -B 1 CVE-2022-0778
* Wed Mar 23 2022 Clemens Lang <cllang@redhat.com> - 1:1.1.1k-6
- Fixes CVE-2022-0778 openssl: Infinite loop in BN_mod_sqrt() reachable when parsing certificates
```

## How was this code tested?

`make build`

## Assignees

/cc @carbonin 


## Links

https://github.com/openshift/assisted-image-service/pull/69

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
