### PR TITLE
OCPBUGSM-46219: OCPBUGSM-46220: Update golang version to 1.18.1.

### DIFF
--- a/Dockerfile.image-service-build
+++ b/Dockerfile.image-service-build
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.17
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 yum install -y install podman genisoimage && yum clean all
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.0
 GOFLAGS='' go install golang.org/x/tools/cmd/goimports@v0.1.5
 GOFLAGS='' go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
Due to several CVE bugs we need to update golang version to >= v1.18.1.
https://bugzilla.redhat.com/show_bug.cgi?id=2077688
https://bugzilla.redhat.com/show_bug.cgi?id=2077689

This PR updates golang version to v1.18.1 and golangci to v1.46.0.