### PR TITLE
Update go-diskfs to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e
-	github.com/diskfs/go-diskfs v1.2.1-0.20210727185522-a769efacd235
+	github.com/diskfs/go-diskfs v1.2.1-0.20221201153419-70aa09455238
 	github.com/golang/mock v1.6.0
 	github.com/google/renameio v0.1.0
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/diskfs/go-diskfs v1.2.1-0.20210727185522-a769efacd235 h1:+NFKI4ptfB3AKeut6a538wanUHOKEMwZfznBZZ6a5Qc=
 github.com/diskfs/go-diskfs v1.2.1-0.20210727185522-a769efacd235/go.mod h1:IoDpuEbpS+D+yCGdoOm6GNfyTeEws77ALvcMQFxmenw=
+github.com/diskfs/go-diskfs v1.2.1-0.20221201153419-70aa09455238 h1:snK/4Yowd4jL5akSDHZLKnakq3nsFCqki9adiGjyenc=
+github.com/diskfs/go-diskfs v1.2.1-0.20221201153419-70aa09455238/go.mod h1:3pUpCAz75Q11om5RsGpVKUgXp2Z+ATw1xV500glmCP0=
 github.com/emicklei/go-restful v2.14.2+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -89,6 +91,7 @@ github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -133,6 +136,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -440,6 +444,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Image integration tests", func() {
 					isoFilename = isoFile.Name()
 
 					By("opening the iso")
-					d, err := diskfs.OpenWithMode(isoFilename, diskfs.ReadOnly)
+					d, err := diskfs.Open(isoFilename, diskfs.WithOpenMode(diskfs.ReadOnly))
 					Expect(err).NotTo(HaveOccurred())
 					fs, err := d.GetFilesystem(0)
 					Expect(err).NotTo(HaveOccurred())

--- a/pkg/isoeditor/isoutil.go
+++ b/pkg/isoeditor/isoutil.go
@@ -17,7 +17,7 @@ import (
 
 // Extract unpacks the iso contents into the working directory
 func Extract(isoPath string, workDir string) error {
-	d, err := diskfs.OpenWithMode(isoPath, diskfs.ReadOnly)
+	d, err := diskfs.Open(isoPath, diskfs.WithOpenMode(diskfs.ReadOnly))
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func Create(outPath string, workDir string, volumeLabel string) error {
 	// we were writing to a particular partition on a device, but we are
 	// not so the minimum iso size will work for us here
 	minISOSize := 38 * 1024
-	d, err := diskfs.Create(outPath, int64(minISOSize), diskfs.Raw)
+	d, err := diskfs.Create(outPath, int64(minISOSize), diskfs.Raw, diskfs.SectorSizeDefault)
 	if err != nil {
 		return err
 	}
@@ -227,7 +227,7 @@ func VolumeIdentifier(isoPath string) (string, error) {
 }
 
 func GetISOFileInfo(filePath, isoPath string) (int64, int64, error) {
-	d, err := diskfs.OpenWithMode(isoPath, diskfs.ReadOnly)
+	d, err := diskfs.Open(isoPath, diskfs.WithOpenMode(diskfs.ReadOnly))
 	if err != nil {
 		return 0, 0, err
 	}
@@ -250,7 +250,7 @@ func GetISOFileInfo(filePath, isoPath string) (int64, int64, error) {
 
 // Gets a readWrite seeker of a specific file from the ISO image
 func GetFileFromISO(isoPath, filePath string) (filesystem.File, error) {
-	d, err := diskfs.OpenWithMode(isoPath, diskfs.ReadOnly)
+	d, err := diskfs.Open(isoPath, diskfs.WithOpenMode(diskfs.ReadOnly))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/isoeditor/isoutil_test.go
+++ b/pkg/isoeditor/isoutil_test.go
@@ -56,7 +56,7 @@ var _ = Context("with test files", func() {
 
 			Expect(Create(isoPath, filesDir, "my-vol")).To(Succeed())
 
-			d, err := diskfs.OpenWithMode(isoPath, diskfs.ReadOnly)
+			d, err := diskfs.Open(isoPath, diskfs.WithOpenMode(diskfs.ReadOnly))
 			Expect(err).ToNot(HaveOccurred())
 			fs, err := d.GetFilesystem(0)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/isoeditor/stream_test.go
+++ b/pkg/isoeditor/stream_test.go
@@ -37,7 +37,7 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 	})
 
 	isoFileContent := func(isoPath, filePath string) []byte {
-		d, err := diskfs.OpenWithMode(isoPath, diskfs.ReadOnly)
+		d, err := diskfs.Open(isoPath, diskfs.WithOpenMode(diskfs.ReadOnly))
 		Expect(err).NotTo(HaveOccurred())
 
 		fs, err := d.GetFilesystem(0)


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

This includes a fix for a panic when we attempt to open a fedora server ISO.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

```
$ export OS_IMAGES='[{"openshift_version": "4.8","cpu_architecture": "x86_64","url": "https://download.fedoraproject.org/pub/fedora/linux/releases/37/Server/x86_64/iso/Fedora-Server-dvd-x86_64-37-1.7.iso","version": "48.84.202109241901-0"}]'
$ IMAGE=quay.io/carbonin/assisted-image-service:latest make build run
```

Before the update this resulted in:

```
{"file":"/go/src/github.com/openshift/origin/pkg/servers/servers.go:94","func":"github.com/openshift/assisted-image-service/pkg/servers.(*ServerInfo).httpsListen","level":"info","msg":"Starting https handler on :8080...","time":"2022-12-01T13:55:56Z"}
{"file":"/go/src/github.com/openshift/origin/pkg/imagestore/imagestore.go:277","func":"github.com/openshift/assisted-image-service/pkg/imagestore.(*rhcosStore).cleanDataDir","level":"info","msg":"Removing /data/.gitkeep from data directory","time":"2022-12-01T13:55:56Z"}
{"file":"/go/src/github.com/openshift/origin/pkg/imagestore/imagestore.go:277","func":"github.com/openshift/assisted-image-service/pkg/imagestore.(*rhcosStore).cleanDataDir","level":"info","msg":"Removing /data/isoutil866884391 from data directory","time":"2022-12-01T13:55:56Z"}
{"file":"/go/src/github.com/openshift/origin/pkg/imagestore/imagestore.go:210","func":"github.com/openshift/assisted-image-service/pkg/imagestore.(*rhcosStore).Populate","level":"info","msg":"Creating minimal iso for 4.8-48.84.202109241901-0-x86_64","time":"2022-12-01T13:55:56Z"}
panic: runtime error: slice bounds out of range [:32768] with capacity 17408

goroutine 33 [running]:
github.com/diskfs/go-diskfs/partition/gpt.tableFromBytes({0xc000394000, 0xc000394000, 0x4400}, 0x200, 0x0)
	/go/pkg/mod/github.com/diskfs/go-diskfs@v1.2.1-0.20210727185522-a769efacd235/partition/gpt/table.go:378 +0xcc5
github.com/diskfs/go-diskfs/partition/gpt.Read({0x9f0070, 0xc0002aa130}, 0x200, 0x50)
	/go/pkg/mod/github.com/diskfs/go-diskfs@v1.2.1-0.20210727185522-a769efacd235/partition/gpt/table.go:516 +0x165
github.com/diskfs/go-diskfs/partition.Read({0x9f0070, 0xc0002aa130}, 0x91c2a0, 0xc000282501)
	/go/pkg/mod/github.com/diskfs/go-diskfs@v1.2.1-0.20210727185522-a769efacd235/partition/partition.go:16 +0x31
github.com/diskfs/go-diskfs/disk.(*Disk).GetPartitionTable(0xc0002840f0)
	/go/pkg/mod/github.com/diskfs/go-diskfs@v1.2.1-0.20210727185522-a769efacd235/disk/disk.go:55 +0x30
github.com/diskfs/go-diskfs.initDisk(0xc0002aa130, 0x38)
	/go/pkg/mod/github.com/diskfs/go-diskfs@v1.2.1-0.20210727185522-a769efacd235/diskfs.go:237 +0x6f2
github.com/diskfs/go-diskfs.OpenWithMode({0xc000291f40, 0x38}, 0x0)
	/go/pkg/mod/github.com/diskfs/go-diskfs@v1.2.1-0.20210727185522-a769efacd235/diskfs.go:289 +0x157
github.com/openshift/assisted-image-service/pkg/isoeditor.Extract({0xc000291f40, 0x0}, {0xc000288678, 0x17})
	/go/src/github.com/openshift/origin/pkg/isoeditor/isoutil.go:20 +0x31
github.com/openshift/assisted-image-service/pkg/isoeditor.(*rhcosEditor).CreateMinimalISOTemplate(0xc00002c017, {0xc000291f40, 0x38}, {0xc0002ce6c0, 0x43}, {0xc000291e00, 0x3b})
	/go/src/github.com/openshift/origin/pkg/isoeditor/rhcos.go:38 +0x94
github.com/openshift/assisted-image-service/pkg/imagestore.(*rhcosStore).Populate(0xc000240000, {0x9f2f48, 0xc000022080})
	/go/src/github.com/openshift/origin/pkg/imagestore/imagestore.go:218 +0x6c5
main.main.func1()
	/go/src/github.com/openshift/origin/main.go:72 +0x46
created by main.main
	/go/src/github.com/openshift/origin/main.go:71 +0x451
```

After we get:
```
{"file":"/go/src/github.com/openshift/origin/pkg/servers/servers.go:94","func":"github.com/openshift/assisted-image-service/pkg/servers.(*ServerInfo).httpsListen","level":"info","msg":"Starting https handler on :8080...","time":"2022-12-01T13:53:19Z"}
{"file":"/go/src/github.com/openshift/origin/pkg/imagestore/imagestore.go:277","func":"github.com/openshift/assisted-image-service/pkg/imagestore.(*rhcosStore).cleanDataDir","level":"info","msg":"Removing /data/isoutil2801760868 from data directory","time":"2022-12-01T13:53:19Z"}
{"file":"/go/src/github.com/openshift/origin/pkg/imagestore/imagestore.go:210","func":"github.com/openshift/assisted-image-service/pkg/imagestore.(*rhcosStore).Populate","level":"info","msg":"Creating minimal iso for 4.8-48.84.202109241901-0-x86_64","time":"2022-12-01T13:53:19Z"}
{"file":"/go/src/github.com/openshift/origin/main.go:74","func":"main.main.func1","level":"fatal","msg":"Failed to populate image store: failed to create minimal iso template for version map[cpu_architecture:x86_64 openshift_version:4.8 url:https://download.fedoraproject.org/pub/fedora/linux/releases/37/Server/x86_64/iso/Fedora-Server-dvd-x86_64-37-1.7.iso version:48.84.202109241901-0]: remove /data/isoutil866884391/images/pxeboot/rootfs.img: no such file or directory\n","time":"2022-12-01T13:53:28Z"}
```

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @CrystalChun 
/cc @danielerez 

## Links
<!--
List any applicable links to related PRs or issues
-->

Related to: https://issues.redhat.com/browse/MGMT-12740
go-diskfs PR: https://github.com/diskfs/go-diskfs/pull/158

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
