### PR TITLE
MGMT-12840: set restricted list of approvers for 2.7

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,30 +2,8 @@
 
 aliases:
   approvers:
-    - eranco74
-    - filanov
-    - gamli75
     - romfreiman
-    - avishayt
-    - eranco74
     - filanov
     - gamli75
-    - ori-amizur
-    - tsorya
-    - nmagnezi
-    - carbonin
-    - danielerez
-    - slaviered
-    - omertuc
-    - eliorerz
     - osherdp
-    - flaper87
-    - mkowalski
-  emeritus_approvers:
-    - empovit
-    - yevgeny-shnaidman
-    - rwsu
-    - lranjbar
-    - pawanpinjarkar
-    - sagidayan
-    - ybettan
+    - carbonin


### PR DESCRIPTION
Since there are (currently) no label restrictions on attached Jira bugs, we don't have a good way to enforce people are only merging bug-fixes / security-patches.

Setting a smaller approvers list can help us enforce this kind of restriction (list might change later on, if needed)

## How was this code tested?

No tests required.

## Assignees

/cc @filanov @gamli75 @romfreiman @carbonin 

## Links

https://issues.redhat.com/browse/MGMT-12840

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
