### PR TITLE
MGMT-12548: Return a more graceful error if ASSISTED_SERVICE_HOST not set

### DIFF
--- a/internal/handlers/assisted_service_client.go
+++ b/internal/handlers/assisted_service_client.go
@@ -23,6 +23,9 @@ type AssistedServiceClient struct {
 const fileRouteFormat = "/api/assisted-install/v2/infra-envs/%s/downloads/files"
 
 func NewAssistedServiceClient(assistedServiceScheme, assistedServiceHost, caCertFile string) (*AssistedServiceClient, error) {
+	if len(assistedServiceHost) == 0 {
+		return nil, fmt.Errorf("ASSISTED_SERVICE_HOST is not set")
+	}
 	client := &http.Client{}
 	if caCertFile != "" {
 		caCert, err := ioutil.ReadFile(caCertFile)
@@ -55,9 +58,6 @@ func NewAssistedServiceClient(assistedServiceScheme, assistedServiceHost, caCert
 // The returned code should only be used if an error is also returned
 func (c *AssistedServiceClient) ramdiskContent(imageServiceRequest *http.Request, imageID string) ([]byte, int, error) {
 	var ramdiskBytes []byte
-	if c.assistedServiceHost == "" {
-		return nil, 0, nil
-	}
 
 	u := url.URL{
 		Scheme: c.assistedServiceScheme,
@@ -94,9 +94,6 @@ func (c *AssistedServiceClient) ramdiskContent(imageServiceRequest *http.Request
 // The code is also returned to ensure issues with authentication from the assisted service request are communicated back to the image service user
 // The returned code should only be used if an error is also returned
 func (c *AssistedServiceClient) ignitionContent(imageServiceRequest *http.Request, imageID string, imageType string) (*isoeditor.IgnitionContent, string, int, error) {
-	if c.assistedServiceHost == "" {
-		return nil, "", 0, nil
-	}
 
 	u := url.URL{
 		Scheme: c.assistedServiceScheme,
@@ -137,9 +134,6 @@ const infraEnvPathFormat = "/api/assisted-install/v2/infra-envs/%s"
 // The code is also returned to ensure issues with authentication from the assisted service request are communicated back to the image service user
 // The returned code should only be used if an error is also returned
 func (c *AssistedServiceClient) discoveryKernelArguments(imageServiceRequest *http.Request, infraEnvID string) ([]byte, int, error) {
-	if c.assistedServiceHost == "" {
-		return nil, 0, nil
-	}
 
 	u := url.URL{
 		Scheme: c.assistedServiceScheme,

--- a/internal/handlers/assisted_service_client_test.go
+++ b/internal/handlers/assisted_service_client_test.go
@@ -1,0 +1,16 @@
+package handlers
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AssistedServiceClient", func() {
+
+	It("should fail with an error when trying to create new client without ASSISTED_SERVICE_HOST set", func() {
+		_, err := NewAssistedServiceClient("http", "", "")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("ASSISTED_SERVICE_HOST is not set"))
+	})
+
+})


### PR DESCRIPTION
… 

## Description
Presently, if the user does not provide ASSISTED_SERVICE_HOST before running the service, there will be a nil dereference error. This was due to the absence of ASSISTED_SERVICE_HOST not being correctly validated. This PR changes that by introducing a clear validation around this.


## How was this code tested?

I introduced a unit test and also performed a manual check.

This test was tested by using the reproduction steps in https://issues.redhat.com/browse/MGMT-12548 , namely

1. clone the repo
2. run `make run`
3. issue the following request 

curl -i -k "https://127.0.0.1:8080/images/d4af4288-65af-4507-995e-43a9a96f857a?arch=x86_64&image_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2Njk1NzEzOTIsInN1YiI6ImQ0YWY0Mjg4LTY1YWYtNDUwNy05OTVlLTQzYTlhOTZmODU3YSJ9.j9HQZnLVIcJkA5Hea1HCG1qkqcMSLQhaS3nDZkq8blQ&type=minimal-iso&version=4.11"

Observed that I received a 500 error and that in the logs I saw

`{"file":"/go/src/github.com/openshift/origin/internal/handlers/iso.go:49","func":"github.com/openshift/assisted-image-service/internal/handlers.(*isoHandler).ServeHTTP","level":"error","msg":"Error retrieving ignition content: ASSISTED_SERVICE_HOST is not set\n","time":"2022-12-07T13:44:48Z"}`

When previously I would see a stack trace (see https://issues.redhat.com/browse/MGMT-12548) that indicated a panic because of an attempt to dereference a nil value.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @ori-amizur 
/cc @osherdp 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
