### PR TITLE
Support ppc64le and s390x

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -60,6 +60,18 @@ var (
 			"url":               "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live.aarch64.iso",
 			"version":           "arm-latest",
 		},
+		{
+			"openshift_version": "4.11",
+			"cpu_architecture":  "s390x",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-s390x-live.s390x.iso",
+			"version":           "s390x-latest",
+		},
+		{
+			"openshift_version": "4.11",
+			"cpu_architecture":  "ppc64le",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-ppc64le-live.ppc64le.iso",
+			"version":           "ppc64le-latest",
+		},
 	}
 
 	imageDir            string
@@ -184,6 +196,15 @@ var _ = Describe("Image integration tests", func() {
 				version := versions[i]
 
 				It("returns a properly generated "+tc.name+" iso image "+version["version"], func() {
+					if version["cpu_architecture"] == "s390x" {
+						if tc.imageType == imagestore.ImageTypeMinimal {
+							Skip("minimal ISO is not supported for s390x architecture")
+						}
+						if tc.expectedExtraKargs != nil {
+							Skip("Karg editing is not supported for s390x architecture")
+						}
+					}
+
 					By("getting an iso")
 					path := fmt.Sprintf("/images/%s?version=%s&type=%s&arch=%s", imageID, version["openshift_version"], tc.imageType, version["cpu_architecture"])
 					resp, err := imageClient.Get(imageServer.URL + path)

--- a/internal/handlers/iso.go
+++ b/internal/handlers/iso.go
@@ -69,6 +69,11 @@ func (h *isoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if kargs != nil && params.arch == "s390x" {
+		httpErrorf(w, http.StatusBadRequest, "kargs cannot be modified in s390x architecture ISOs")
+		return
+	}
+
 	isoReader, err := h.GenerateImageStream(h.ImageStore.PathForParams(params.imageType, params.version, params.arch), ignition, ramdisk, kargs)
 	if err != nil {
 		log.Errorf("Error creating image stream: %v\n", err)

--- a/internal/handlers/iso_test.go
+++ b/internal/handlers/iso_test.go
@@ -275,6 +275,16 @@ var _ = Describe("ServeHTTP", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
 			})
+
+			It("fails when kargs are supplied for an s390x image", func() {
+				initIgnitionHandler("discovery_iso_type=full-iso&file_name=discovery.ign")
+				mockImage("4.11", imagestore.ImageTypeFull, "s390x")
+				path := fmt.Sprintf("/images/%s?version=4.11&type=full-iso&arch=s390x", imageID)
+				setInfraenvKargsHandlerSuccess("arg")
+				resp, err := client.Get(server.URL + path)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+			})
 		})
 
 		It("passes Authorization header through to assisted requests", func() {

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -241,7 +241,7 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 				return fmt.Errorf("failed to build rootfs URL: %v", err)
 			}
 
-			err = s.isoEditor.CreateMinimalISOTemplate(fullPath, rootfsURL, minimalPath)
+			err = s.isoEditor.CreateMinimalISOTemplate(fullPath, rootfsURL, arch, minimalPath)
 			if err != nil {
 				return fmt.Errorf("failed to create minimal iso template for version %s: %v", imageInfo, err)
 			}

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -226,6 +226,11 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 		imageVersion := imageInfo["version"]
 		arch := imageInfo["cpu_architecture"]
 
+		// Don't attempt to create a minimal ISO for s390x because there's no easy way to edit the kernel parameters
+		// This means that the rootfs URL can't be added which makes it impossible for us to create a minimal ISO
+		if arch == "s390x" {
+			continue
+		}
 		minimalPath := filepath.Join(s.dataDir, isoFileName(ImageTypeMinimal, openshiftVersion, imageVersion, arch))
 		if _, err := os.Stat(minimalPath); os.IsNotExist(err) {
 			log.Infof("Creating minimal iso for %s-%s-%s", openshiftVersion, imageVersion, arch)

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -101,7 +101,7 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, gomock.Any()).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any()).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
@@ -153,7 +153,7 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, gomock.Any()).Return(fmt.Errorf("minimal iso creation failed"))
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any()).Return(fmt.Errorf("minimal iso creation failed"))
 				Expect(is.Populate(ctx)).NotTo(Succeed())
 			})
 
@@ -171,7 +171,7 @@ var _ = Context("with a data directory configured", func() {
 				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, gomock.Any()).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any()).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 			})
 
@@ -186,7 +186,7 @@ var _ = Context("with a data directory configured", func() {
 				Expect(os.WriteFile(minimalPath, []byte("minimalisocontent"), 0600)).To(Succeed())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(fullPath, rootfs, minimalPath).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(fullPath, rootfs, "x86_64", minimalPath).Return(nil)
 
 				Expect(is.Populate(ctx)).To(Succeed())
 			})
@@ -204,7 +204,7 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, versionPatch["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, gomock.Any()).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any()).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8.1-48.84.202109241901-0-x86_64.iso"))
@@ -228,7 +228,7 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, gomock.Any()).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any()).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				_, err = os.Stat(oldISOPath)
@@ -258,7 +258,7 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(mockEditor, dataDir, "", false, []map[string]string{version})
 				Expect(err).NotTo(HaveOccurred())
 
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "", gomock.Any()).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "", "x86_64", gomock.Any()).Return(nil)
 				Expect(is.Populate(ctx)).NotTo(Succeed())
 			})
 
@@ -276,7 +276,7 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				rootfs := fmt.Sprintf("https://images.example.com/api/assisted-images/boot-artifacts/rootfs?arch=x86_64&version=%s", version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, gomock.Any()).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any()).Return(nil)
 				err = is.Populate(ctx)
 				Expect(err).ToNot(Succeed())
 				Expect(err.Error()).To(Equal("failed to build rootfs URL: parse \":\": missing protocol scheme"))

--- a/pkg/isoeditor/mock_editor.go
+++ b/pkg/isoeditor/mock_editor.go
@@ -34,15 +34,15 @@ func (m *MockEditor) EXPECT() *MockEditorMockRecorder {
 }
 
 // CreateMinimalISOTemplate mocks base method.
-func (m *MockEditor) CreateMinimalISOTemplate(arg0, arg1, arg2 string) error {
+func (m *MockEditor) CreateMinimalISOTemplate(arg0, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMinimalISOTemplate", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CreateMinimalISOTemplate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateMinimalISOTemplate indicates an expected call of CreateMinimalISOTemplate.
-func (mr *MockEditorMockRecorder) CreateMinimalISOTemplate(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEditorMockRecorder) CreateMinimalISOTemplate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMinimalISOTemplate", reflect.TypeOf((*MockEditor)(nil).CreateMinimalISOTemplate), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMinimalISOTemplate", reflect.TypeOf((*MockEditor)(nil).CreateMinimalISOTemplate), arg0, arg1, arg2, arg3)
 }

--- a/pkg/isoeditor/rhcos_test.go
+++ b/pkg/isoeditor/rhcos_test.go
@@ -83,23 +83,25 @@ var _ = Context("with test files", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+	It("fixGrubConfig alters the kernel parameters correctly", func() {
+		err := fixGrubConfig(testRootFSURL, filesDir)
+		Expect(err).ToNot(HaveOccurred())
 
-	Describe("fixTemplateConfigs", func() {
-		It("alters the kernel parameters correctly", func() {
-			err := fixTemplateConfigs(testRootFSURL, filesDir)
-			Expect(err).ToNot(HaveOccurred())
+		newLine := "	linux /images/pxeboot/vmlinuz random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal 'coreos.live.rootfs_url=%s'"
+		grubCfg := fmt.Sprintf(newLine, testRootFSURL)
+		validateFileContainsLine(filepath.Join(filesDir, "EFI/redhat/grub.cfg"), grubCfg)
 
-			newLine := "	linux /images/pxeboot/vmlinuz random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal 'coreos.live.rootfs_url=%s'"
-			grubCfg := fmt.Sprintf(newLine, testRootFSURL)
-			validateFileContainsLine(filepath.Join(filesDir, "EFI/redhat/grub.cfg"), grubCfg)
+		newLine = "	initrd /images/pxeboot/initrd.img /images/ignition.img %s"
+		grubCfg = fmt.Sprintf(newLine, ramDiskImagePath)
+		validateFileContainsLine(filepath.Join(filesDir, "EFI/redhat/grub.cfg"), grubCfg)
 
-			newLine = "	initrd /images/pxeboot/initrd.img /images/ignition.img %s"
-			grubCfg = fmt.Sprintf(newLine, ramDiskImagePath)
-			validateFileContainsLine(filepath.Join(filesDir, "EFI/redhat/grub.cfg"), grubCfg)
+	})
+	It("fixIsolinuxConfig alters the kernel parameters correctly", func() {
+		err := fixIsolinuxConfig(testRootFSURL, filesDir)
+		Expect(err).ToNot(HaveOccurred())
 
-			newLine = "  append initrd=/images/pxeboot/initrd.img,/images/ignition.img,%s random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal coreos.live.rootfs_url=%s"
-			isolinuxCfg := fmt.Sprintf(newLine, ramDiskImagePath, testRootFSURL)
-			validateFileContainsLine(filepath.Join(filesDir, "isolinux/isolinux.cfg"), isolinuxCfg)
-		})
+		newLine := "  append initrd=/images/pxeboot/initrd.img,/images/ignition.img,%s random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal coreos.live.rootfs_url=%s"
+		isolinuxCfg := fmt.Sprintf(newLine, ramDiskImagePath, testRootFSURL)
+		validateFileContainsLine(filepath.Join(filesDir, "isolinux/isolinux.cfg"), isolinuxCfg)
 	})
 })

--- a/pkg/isoeditor/rhcos_test.go
+++ b/pkg/isoeditor/rhcos_test.go
@@ -58,13 +58,13 @@ var _ = Context("with test files", func() {
 		It("iso created successfully", func() {
 			editor := NewEditor(workDir)
 
-			err := editor.CreateMinimalISOTemplate(isoFile, testRootFSURL, minimalISOPath)
+			err := editor.CreateMinimalISOTemplate(isoFile, testRootFSURL, "x86_64", minimalISOPath)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("missing iso file", func() {
 			editor := NewEditor(workDir)
-			err := editor.CreateMinimalISOTemplate("invalid", testRootFSURL, minimalISOPath)
+			err := editor.CreateMinimalISOTemplate("invalid", testRootFSURL, "x86_64", minimalISOPath)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -73,13 +73,13 @@ var _ = Context("with test files", func() {
 		It("iso created successfully", func() {
 			editor := NewEditor(workDir)
 
-			err := editor.CreateMinimalISOTemplate(isoFile, testFCOSRootFSURL, minimalISOPath)
+			err := editor.CreateMinimalISOTemplate(isoFile, testFCOSRootFSURL, "x86_64", minimalISOPath)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("missing iso file", func() {
 			editor := NewEditor(workDir)
-			err := editor.CreateMinimalISOTemplate("invalid", testFCOSRootFSURL, minimalISOPath)
+			err := editor.CreateMinimalISOTemplate("invalid", testFCOSRootFSURL, "x86_64", minimalISOPath)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
## Description

@carbonin and I worked on this together to enable ppc64le (Power) and s390x (Z) architectures in the assisted-image-service. This is related to the [PR](https://github.com/openshift/assisted-service/pull/4796) in the assisted-service to enable these architectures related to this multi-arch [epic](https://issues.redhat.com/browse/MULTIARCH-2889).

We're working around some limitations with s390x as it doesn't use grub, which also means we can't extract a minimal iso from it. The CoreOS team is [working on](https://issues.redhat.com/browse/COS-1924) enabling minimal iso extraction for s390x at the moment. If/when they get it working we can revisit some of these changes, but for now we're just going to skip minimal iso extraction for s390x.

Neither architecture has an isolinux.cfg file, so we had to make some changes to avoid errors when trying to edit it. 

Also made some changes to the integration tests to take these two architectures into account and avoid errors.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
Integration tests validate that we can download the ISOs of these architectures.

In the assisted-service [PR](https://github.com/openshift/assisted-service/pull/4796), we will do additional testing.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mkowalski 
/cc @danielerez 

## Links
<!--
List any applicable links to related PRs or issues
-->
[Epic](https://issues.redhat.com/browse/MULTIARCH-2889) for enabling P/Z in Assisted Installer
[PR](https://github.com/openshift/assisted-service/pull/4796) for assisted-service
[Ticket](https://issues.redhat.com/browse/COS-1924) for CoreOS to enable minimal ISO extraction 

## Checklist

- [X] Title and description added to both, commit and PR
- [X] Relevant issues have been associated
- [X] Reviewers have been listed
- [X] Not yet - This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Unsure - Does this change include unit tests (note that code changes require unit tests)