### PR TITLE
AGENT-438: Allow initramfs to be read directly from ISO

### DIFF
--- a/pkg/isoeditor/initramfs.go
+++ b/pkg/isoeditor/initramfs.go
@@ -1,18 +1,32 @@
 package isoeditor
 
 import (
+	"io"
 	"os"
 
 	"github.com/openshift/assisted-image-service/pkg/overlay"
 	"github.com/pkg/errors"
 )
 
+const initrdPathInISO = "images/pxeboot/initrd.img"
+
 func NewInitRamFSStreamReader(irfsPath string, ignitionContent *IgnitionContent) (overlay.OverlayReader, error) {
 	irfsReader, err := os.Open(irfsPath)
 	if err != nil {
 		return nil, err
 	}
+	return newInitRamFSStreamReaderFromStream(irfsReader, ignitionContent)
+}
 
+func NewInitRamFSStreamReaderFromISO(isoPath string, ignitionContent *IgnitionContent) (overlay.OverlayReader, error) {
+	irfsReader, err := GetFileFromISO(isoPath, initrdPathInISO)
+	if err != nil {
+		return nil, err
+	}
+	return newInitRamFSStreamReaderFromStream(irfsReader, ignitionContent)
+}
+
+func newInitRamFSStreamReaderFromStream(irfsReader io.ReadSeekCloser, ignitionContent *IgnitionContent) (overlay.OverlayReader, error) {
 	ignitionReader, err := ignitionContent.Archive()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Because `NewInitRamFSStreamReader()` takes a filename as an input, this requires us to copy the initramfs to a temporary file if we are retrieving it from inside an ISO.

Add a separate `NewInitRamFSStreamReaderFromISO()` function that takes the filename of the ISO instead, so that we can output an initramfs with Ignition from an ISO input without temporary files.