### PR TITLE
MGMT-12975: Update 4.12 release image to use GA version

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -47,14 +47,14 @@ parameters:
       {
         "openshift_version": "4.12",
         "cpu_architecture": "x86_64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.12.0-ec.2/rhcos-4.12.0-ec.2-x86_64-live.x86_64.iso",
-        "version": "412.86.202208101039-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live.x86_64.iso",
+        "version": "412.86.202212081411-0"
       },
       {
         "openshift_version": "4.12",
         "cpu_architecture": "arm64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/4.12.0-ec.2/rhcos-4.12.0-ec.2-aarch64-live.aarch64.iso",
-        "version": "412.86.202208101040-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-aarch64-live.aarch64.iso",
+        "version": "412.86.202212081411-0"
       }
     ]
   required: false


### PR DESCRIPTION
Update 4.12 images to the GA ones 

/cc @gamli75 
/cc @osherdp 
