### PR TITLE
NO-ISSUE: Update 4.13 images to actual 4.12 releases

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -59,13 +59,13 @@ parameters:
       {
         "openshift_version": "4.13",
         "cpu_architecture": "x86_64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.12.0-ec.2/rhcos-4.12.0-ec.2-x86_64-live.x86_64.iso",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live.x86_64.iso",
         "version": "412.86.202208101039-0"
       },
       {
         "openshift_version": "4.13",
         "cpu_architecture": "arm64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/4.12.0-ec.2/rhcos-4.12.0-ec.2-aarch64-live.aarch64.iso",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-aarch64-live.aarch64.iso",
         "version": "412.86.202208101040-0"
       }
     ]


### PR DESCRIPTION
We updated (by mistake) in https://github.com/openshift/assisted-image-service/pull/111 the ec images instead of the actual releases, this PR fixes that.

/cc @carbonin 
/cc @osherdp 
/cc @gamli75 
