### PR TITLE
Update base ISO images to assisted-service data

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -11,38 +11,50 @@ parameters:
       {
         "openshift_version": "4.8",
         "cpu_architecture": "x86_64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso",
         "version": "48.84.202109241901-0"
       },
       {
         "openshift_version": "4.9",
         "cpu_architecture": "x86_64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-4.9.40-x86_64-live.x86_64.iso",
-        "version": "49.84.202206171736-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.9/4.9.45/rhcos-4.9.45-x86_64-live.x86_64.iso",
+        "version": "49.84.202207192205-0"
       },
       {
         "openshift_version": "4.10",
         "cpu_architecture": "x86_64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live.x86_64.iso",
-        "version": "410.84.202205191234-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.10/4.10.37/rhcos-4.10.37-x86_64-live.x86_64.iso",
+        "version": "410.84.202210040010-0"
       },
       {
         "openshift_version": "4.10",
         "cpu_architecture": "arm64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-aarch64-live.aarch64.iso",
-        "version": "410.84.202205191023-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.37/rhcos-4.10.37-aarch64-live.aarch64.iso",
+        "version": "410.84.202210040011-0"
       },
       {
         "openshift_version": "4.11",
         "cpu_architecture": "x86_64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.11/4.11.2/rhcos-4.11.2-x86_64-live.x86_64.iso",
-        "version": "411.86.202208112011-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live.x86_64.iso",
+        "version": "411.86.202210041459-0"
       },
       {
         "openshift_version": "4.11",
         "cpu_architecture": "arm64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.11/4.11.2/rhcos-4.11.2-aarch64-live.aarch64.iso",
-        "version": "411.86.202208111758-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-aarch64-live.aarch64.iso",
+        "version": "411.86.202210032347-0"
+      },
+      {
+        "openshift_version": "4.11",
+        "cpu_architecture": "s390x",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-s390x-live.s390x.iso",
+        "version": "411.86.202210171842-0"
+      },
+      {
+        "openshift_version": "4.11",
+        "cpu_architecture": "ppc64le",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-ppc64le-live.ppc64le.iso",
+        "version": "411.86.202210171844-0"
       },
       {
         "openshift_version": "4.12",
@@ -57,16 +69,28 @@ parameters:
         "version": "412.86.202212081411-0"
       },
       {
+        "openshift_version": "4.12",
+        "cpu_architecture": "s390x",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-s390x-live.s390x.iso",
+        "version": "412.86.202212081411-0"
+      },
+      {
+        "openshift_version": "4.12",
+        "cpu_architecture": "ppc64le",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-ppc64le-live.ppc64le.iso",
+        "version": "412.86.202212081411-0"
+      },
+      {
         "openshift_version": "4.13",
         "cpu_architecture": "x86_64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.12.0-ec.2/rhcos-4.12.0-ec.2-x86_64-live.x86_64.iso",
-        "version": "412.86.202208101039-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live.x86_64.iso",
+        "version": "412.86.202212081411-0"
       },
       {
         "openshift_version": "4.13",
         "cpu_architecture": "arm64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/4.12.0-ec.2/rhcos-4.12.0-ec.2-aarch64-live.aarch64.iso",
-        "version": "412.86.202208101040-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-aarch64-live.aarch64.iso",
+        "version": "412.86.202212081411-0"
       }
     ]
   required: false


### PR DESCRIPTION
## Description

This brings the ISO urls up to date with the data in the assisted-service repo.

This will only affect the integration SaaS environment.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

`oc process -f template.yaml --local=true -pIMAGE_SERVICE_BASE_URL=image-service.example.com -pIMAGE_TAG=latest` 
succeeds


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @eliorerz 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
