### PR TITLE
Add support for 4.13 dev preview images

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -83,26 +83,26 @@ parameters:
       {
         "openshift_version": "4.13",
         "cpu_architecture": "x86_64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live.x86_64.iso",
-        "version": "412.86.202212081411-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest-4.13/rhcos-4.13.0-ec.3-x86_64-live.x86_64.iso",
+        "version": "413.86.202302162343-0"
       },
       {
         "openshift_version": "4.13",
         "cpu_architecture": "arm64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-aarch64-live.aarch64.iso",
-        "version": "412.86.202212081411-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/latest-4.13/rhcos-4.13.0-ec.3-aarch64-live.aarch64.iso",
+        "version": "413.86.202302162338-0"
       },
       {
         "openshift_version": "4.13",
         "cpu_architecture": "ppc64le",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-ppc64le-live.ppc64le.iso",
-        "version": "412.86.202212081411-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/pre-release/latest-4.13/rhcos-4.13.0-ec.3-ppc64le-live.ppc64le.iso",
+        "version": "413.86.202302162338-0"
       },
       {
         "openshift_version": "4.13",
         "cpu_architecture": "s390x",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-s390x-live.s390x.iso",
-        "version": "412.86.202212081411-0"
+        "url": "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/pre-release/latest-4.13/rhcos-4.13.0-ec.3-s390x-live.s390x.iso",
+        "version": "413.86.202302162339-0"
       }
     ]
   required: false

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -91,6 +91,18 @@ parameters:
         "cpu_architecture": "arm64",
         "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-aarch64-live.aarch64.iso",
         "version": "412.86.202212081411-0"
+      },
+      {
+        "openshift_version": "4.13",
+        "cpu_architecture": "ppc64le",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-ppc64le-live.ppc64le.iso",
+        "version": "412.86.202212081411-0"
+      },
+      {
+        "openshift_version": "4.13",
+        "cpu_architecture": "s390x",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-s390x-live.s390x.iso",
+        "version": "412.86.202212081411-0"
       }
     ]
   required: false


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->
Adds 4.12 ppc64le and s390x ISOs for 4.13 dev preview testing, in parity with #111 and #115.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
Did not test, am having some troubles with getting my assisted-service running.
Ok to let CI test?

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @eliorerz 
/cc @carbonin
/cc @osherdp
/cc @gamli75 

## Links
<!--
List any applicable links to related PRs or issues
-->
#111 
#115
[PR](https://github.com/openshift/assisted-service/pull/5005) in assisted-service

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
