### PR TITLE
MGMT-13935: validateISOID: allow SCOS images

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -60,6 +60,12 @@ var (
 			"url":               "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live.aarch64.iso",
 			"version":           "arm-latest",
 		},
+		{
+			"openshift_version": "scos-prerelease",
+			"cpu_architecture":  "x86_64",
+			"url":               "https://okd-scos.s3.amazonaws.com/okd-scos/builds/413.9.202302280609-0/x86_64/scos-413.9.202302280609-0-live.x86_64.iso",
+			"version":           "x86_64-latest",
+		},
 	}
 
 	imageDir            string

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -171,7 +171,7 @@ func validateISOID(path string) error {
 		return err
 	}
 
-	if !strings.HasPrefix(volumeID, "rhcos-") && !strings.HasPrefix(volumeID, "fedora-coreos-") {
+	if !strings.HasPrefix(volumeID, "rhcos-") && !strings.HasPrefix(volumeID, "fedora-coreos-") && !strings.HasPrefix(volumeID, "scos-") {
 		return fmt.Errorf("ISO volume identifier (%s) is invalid", volumeID)
 	}
 

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -212,6 +212,26 @@ var _ = Context("with a data directory configured", func() {
 				Expect(content).To(Equal(isoContent))
 			})
 
+			It("populates Fedora/Centos images correctly", func() {
+				validVolumeIDs := []string{"fedora-coreos-35.20220101.0.3", "scos-413.9.20231000101-0"}
+				for _, testValidVolumeID := range validVolumeIDs {
+					isoContent, isoHeader := isoInfo(testValidVolumeID)
+					ts.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/somepatchversion.iso"),
+							ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
+						),
+					)
+					versionPatch["url"] = ts.URL() + "/somepatchversion.iso"
+					is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{versionPatch})
+					Expect(err).NotTo(HaveOccurred())
+
+					rootfs := fmt.Sprintf(rootfsURL, versionPatch["openshift_version"])
+					mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, gomock.Any()).Return(nil)
+					Expect(is.Populate(ctx)).To(Succeed())
+				}
+			})
+
 			It("cleans up files that are not configured isos", func() {
 				oldISOPath := filepath.Join(dataDir, "rhcos-full-iso-4.7-47.84.202109241831-0-x86_64.iso")
 				Expect(os.WriteFile(oldISOPath, []byte("oldisocontent"), 0600)).To(Succeed())

--- a/pkg/isoeditor/kargs_test.go
+++ b/pkg/isoeditor/kargs_test.go
@@ -26,6 +26,22 @@ var _ = Context("kargs tests", func() {
   "size": 1137
 }
 `
+		kargsCentOSConfileFile = `
+{
+  "default": "mitigations=auto,nosmt coreos.liveiso=scos-413.9.20230103.0 ignition.firstboot ignition.platform.id=metal",
+  "files": [
+    {
+      "offset": 970,
+      "path": "EFI/centos/grub.cfg"
+    },
+    {
+      "offset": 1870,
+      "path": "isolinux/isolinux.cfg"
+    }
+  ],
+  "size": 1137
+}
+`
 		grubFileWithEmbedArea = `
 function load_video {
   insmod efi_gop
@@ -108,6 +124,11 @@ menuentry 'Fedora CoreOS (Live)' --class fedora --class gnu-linux --class gnu --
 			files, err := kargsFiles("isoPath", mockFileReaderSuccess(kargsConfileFile))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(files).To(Equal([]string{"EFI/fedora/grub.cfg", "isolinux/isolinux.cfg"}))
+		})
+		It("works with centos", func() {
+			files, err := kargsFiles("isoPath", mockFileReaderSuccess(kargsCentOSConfileFile))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(files).To(Equal([]string{"EFI/centos/grub.cfg", "isolinux/isolinux.cfg"}))
 		})
 	})
 	Describe("kargsEmbedAreaBoundariesFinder", func() {

--- a/pkg/isoeditor/rhcos.go
+++ b/pkg/isoeditor/rhcos.go
@@ -88,7 +88,7 @@ func embedInitrdPlaceholders(extractDir string) error {
 }
 
 func fixTemplateConfigs(rootFSURL, extractDir string) error {
-	availableGrubPaths := []string{"EFI/redhat/grub.cfg", "EFI/fedora/grub.cfg"}
+	availableGrubPaths := []string{"EFI/redhat/grub.cfg", "EFI/fedora/grub.cfg", "EFI/centos/grub.cfg"}
 	var foundGrubPath string
 	for _, pathSection := range availableGrubPaths {
 		path := filepath.Join(extractDir, pathSection)


### PR DESCRIPTION
Allow images with "scos-" volume ID
Cherrypick of https://github.com/openshift/assisted-image-service/pull/114 for ACM 2.7