### PR TITLE
OCPBUGS-10948: isoeditor: allow centos images

### DIFF
--- a/pkg/isoeditor/rhcos.go
+++ b/pkg/isoeditor/rhcos.go
@@ -88,7 +88,7 @@ func embedInitrdPlaceholders(extractDir string) error {
 }
 
 func fixTemplateConfigs(rootFSURL, extractDir string) error {
-	availableGrubPaths := []string{"EFI/redhat/grub.cfg", "EFI/fedora/grub.cfg"}
+	availableGrubPaths := []string{"EFI/redhat/grub.cfg", "EFI/fedora/grub.cfg", "EFI/centos/grub.cfg"}
 	var foundGrubPath string
 	for _, pathSection := range availableGrubPaths {
 		path := filepath.Join(extractDir, pathSection)


### PR DESCRIPTION
## Description
Update available grub paths to allow CentOS images, so that CentOS  Stream test images could be parsed correctly


Partial cherrypick of https://github.com/openshift/assisted-image-service/pull/117 on release-ocm-2.6

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @filanov 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
