### PR TITLE
adds ability to set the log level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ IMAGE := $(or ${IMAGE}, quay.io/edge-infrastructure/assisted-image-service:lates
 PWD = $(shell pwd)
 LISTEN_PORT := $(or ${LISTEN_PORT}, 8080)
 IMAGE_SERVICE_BASE_URL := $(or ${IMAGE_SERVICE_BASE_URL}, http://localhost:8080)
+LOG_LEVEL := $(or ${LOG_LEVEL}, info)
 
 CI ?= false
 ROOT_DIR = $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
@@ -51,6 +52,7 @@ run: certs
 		-e RHCOS_VERSIONS='${RHCOS_VERSIONS}' \
 		-e OS_IMAGES='${OS_IMAGES}' \
 		-e HTTP_LISTEN_PORT='${HTTP_LISTEN_PORT}' \
+		-e LOGLEVEL='${LOG_LEVEL}' \
 		$(IMAGE)
 
 .PHONY: certs

--- a/README.md
+++ b/README.md
@@ -22,17 +22,18 @@ skipper make test
 
 ## Configuration
 
-- `DATA_DIR` - Path at which to store downloaded RHCOS images.
-- `RHCOS_VERSIONS`/`OS_IMAGES` - JSON string indicating the supported versions and their required urls. `OS_IMAGES` takes precedence.
-- `LISTEN_PORT` - Image Service listen port
-- `HTTPS_KEY_FILE` - tls key file path
-- `HTTPS_CERT_FILE` - tls cert file path
-- `ASSISTED_SERVICE_SCHEME` - protocol to use to query assisted service for image information
-- `ASSISTED_SERVICE_HOST` - host or host:port to use to query assisted service for image information
-- `IMAGE_SERVICE_BASE_URL` - the base URL to use to query the image service
-- `MAX_CONCURRENT_REQUESTS` - caps the number of inflight image downloads to avoid things like open file limits
 - `ALLOWED_DOMAINS` - When set, determines how the service responds to requests with `Origin` headers
+- `ASSISTED_SERVICE_HOST` - host or host:port to use to query assisted service for image information
+- `ASSISTED_SERVICE_SCHEME` - protocol to use to query assisted service for image information
+- `DATA_DIR` - Path at which to store downloaded RHCOS images.
+- `HTTPS_CERT_FILE` - tls cert file path
+- `HTTPS_KEY_FILE` - tls key file path
 - `HTTP_LISTEN_PORT` - When set, plain http listener is started on that port
+- `IMAGE_SERVICE_BASE_URL` - the base URL to use to query the image service
+- `LISTEN_PORT` - Image Service listen port
+- `LOG_LEVEL` - log level, such as "info" or "debug"; see logrus docs for a complete list
+- `MAX_CONCURRENT_REQUESTS` - caps the number of inflight image downloads to avoid things like open file limits
+- `RHCOS_VERSIONS`/`OS_IMAGES` - JSON string indicating the supported versions and their required urls. `OS_IMAGES` takes precedence.
 
 Example `OS_IMAGES`:
 ```json

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var Options struct {
 	AllowedDomains        string `envconfig:"ALLOWED_DOMAINS"`
 	InsecureSkipVerify    bool   `envconfig:"INSECURE_SKIP_VERIFY" default:"false"`
 	ImageServiceBaseURL   string `envconfig:"IMAGE_SERVICE_BASE_URL"`
+	LogLevel              string `envconfig:"LOGLEVEL" default:"info"`
 }
 
 func main() {
@@ -45,6 +46,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to process config: %v\n", err)
 	}
+	logLevel, err := log.ParseLevel(Options.LogLevel)
+	if err != nil {
+		log.Fatalf("unknown log level: %s", Options.LogLevel)
+	}
+	log.SetLevel(logLevel)
 
 	versionsJSON := Options.OSImages
 	if versionsJSON == "" {


### PR DESCRIPTION
## Description
The log level can now be set via environment variable, enabling developers and operators to see debug messages.


## How was this code tested?
Hand testing and the existing suite of integration tests.

## Assignees

/cc @carbonin 

## Checklist

- [x] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
