### PR TITLE
MGMT-12743: adds support for shorter URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,45 @@ Example `OS_IMAGES`:
 
 ## API
 
+None of these APIs should be considered stable for end-users of assisted
+installer. Users should never construct URLs that match these APIs; instead
+users should obtain an ISO URL from an InfraEnv resource, as provided by
+assisted installer. These APIs represent a contract between
+assisted-image-service and assisted installer only.
+
+### `GET /byid/{image_id}/{version}/{arch}/{filename}`
+
+Downloads the RHCOS image for the specified image ID.
+
+URL segments:
+- `image_id`: ID for the image, usually the InfraEnv ID
+- `version`: indicates the version of the RHCOS base image to use (must match an entry in `RHCOS_VERSIONS`)
+- `arch`: the base image cpu architecture (must match an entry in `RHCOS_VERSIONS`)
+- `filename`: `full.iso` to download the ISO including the rootfs, `minimal.iso` to download the ISO without the rootfs
+
+### `GET /bytoken/{token}/{version}/{arch}/{filename}`
+
+Downloads the RHCOS image for the specified image ID.
+
+URL segments:
+- `token`: JWT whose payload containes either a `sub` field or `infra_env_id` field
+- `version`: indicates the version of the RHCOS base image to use (must match an entry in `RHCOS_VERSIONS`)
+- `arch`: the base image cpu architecture (must match an entry in `RHCOS_VERSIONS`)
+- `filename`: `full.iso` to download the ISO including the rootfs, `minimal.iso` to download the ISO without the rootfs
+
+### `GET /byapikey/{api_key}/{version}/{arch}/{filename}`
+
+Downloads the RHCOS image for the specified image ID.
+
+URL segments:
+- `api_key`: JWT whose payload containes either a `sub` field or `infra_env_id` field
+- `version`: indicates the version of the RHCOS base image to use (must match an entry in `RHCOS_VERSIONS`)
+- `arch`: the base image cpu architecture (must match an entry in `RHCOS_VERSIONS`)
+- `filename`: `full.iso` to download the ISO including the rootfs, `minimal.iso` to download the ISO without the rootfs
+
+
+## Deprecated API
+
 ### `GET /images/{image_id}`
 
 Downloads the RHCOS image for the specified image ID.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e
 	github.com/diskfs/go-diskfs v1.2.1-0.20221201153419-70aa09455238
+	github.com/go-chi/chi/v5 v5.0.8
 	github.com/golang/mock v1.6.0
 	github.com/google/renameio v0.1.0
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/diskfs/go-diskfs v1.2.1-0.20210727185522-a769efacd235 h1:+NFKI4ptfB3AKeut6a538wanUHOKEMwZfznBZZ6a5Qc=
-github.com/diskfs/go-diskfs v1.2.1-0.20210727185522-a769efacd235/go.mod h1:IoDpuEbpS+D+yCGdoOm6GNfyTeEws77ALvcMQFxmenw=
 github.com/diskfs/go-diskfs v1.2.1-0.20221201153419-70aa09455238 h1:snK/4Yowd4jL5akSDHZLKnakq3nsFCqki9adiGjyenc=
 github.com/diskfs/go-diskfs v1.2.1-0.20221201153419-70aa09455238/go.mod h1:3pUpCAz75Q11om5RsGpVKUgXp2Z+ATw1xV500glmCP0=
 github.com/emicklei/go-restful v2.14.2+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -75,7 +73,10 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
+github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
 github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
+github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -91,6 +92,7 @@ github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -134,8 +136,8 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -426,7 +428,6 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -510,7 +511,6 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -112,6 +112,7 @@ var _ = Describe("Image integration tests", func() {
 
 	testcases := []struct {
 		name               string
+		fileName           string
 		imageType          string
 		expectedIgnition   []byte
 		expectedRamdisk    []byte
@@ -120,12 +121,14 @@ var _ = Describe("Image integration tests", func() {
 		{
 			name:             "full-iso",
 			imageType:        imagestore.ImageTypeFull,
+			fileName:         "full.iso",
 			expectedIgnition: []byte("someignitioncontent"),
 			expectedRamdisk:  nil,
 		},
 		{
 			name:               "full-iso-with-kargs",
 			imageType:          imagestore.ImageTypeFull,
+			fileName:           "full.iso",
 			expectedIgnition:   []byte("someignitioncontent"),
 			expectedRamdisk:    nil,
 			expectedExtraKargs: []string{"p1", "p1", `key=value`},
@@ -133,18 +136,21 @@ var _ = Describe("Image integration tests", func() {
 		{
 			name:             "minimal-iso-with-initrd",
 			imageType:        imagestore.ImageTypeMinimal,
+			fileName:         "minimal.iso",
 			expectedIgnition: []byte("someignitioncontent"),
 			expectedRamdisk:  []byte("someramdiskcontent"),
 		},
 		{
 			name:             "minimal-iso-without-initrd",
 			imageType:        imagestore.ImageTypeMinimal,
+			fileName:         "minimal.iso",
 			expectedIgnition: []byte("someignitioncontent"),
 			expectedRamdisk:  []byte(""),
 		},
 		{
 			name:               "minimal-iso-without-initrd-with-kargs",
 			imageType:          imagestore.ImageTypeMinimal,
+			fileName:           "minimal.iso",
 			expectedIgnition:   []byte("someignitioncontent"),
 			expectedRamdisk:    []byte(""),
 			expectedExtraKargs: []string{"p5", "p6", `key=value`},
@@ -212,7 +218,7 @@ var _ = Describe("Image integration tests", func() {
 					}
 
 					By("getting an iso")
-					path := fmt.Sprintf("/images/%s?version=%s&type=%s&arch=%s", imageID, version["openshift_version"], tc.imageType, version["cpu_architecture"])
+					path := fmt.Sprintf("/byid/%s/%s/%s/%s", imageID, version["openshift_version"], version["cpu_architecture"], tc.fileName)
 					resp, err := imageClient.Get(imageServer.URL + path)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(resp.StatusCode).To(Equal(http.StatusOK))

--- a/internal/handlers/images_test.go
+++ b/internal/handlers/images_test.go
@@ -10,14 +10,14 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"golang.org/x/sync/semaphore"
 )
 
 var _ = Describe("ServeHTTP", func() {
 	It("calls the iso handler ServeHTTP", func() {
+		imageID := "bf25292a-dddd-49dc-ab9c-3fb4c1f07071"
 		stubISOHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			Expect(r.Method).To(Equal(http.MethodGet))
-			Expect(r.URL.Path).To(Equal("/images/test-image-id"))
+			Expect(r.URL.Path).To(Equal(fmt.Sprintf("/images/%s", imageID)))
 			http.ServeContent(w, r, "some.iso", time.Now(), strings.NewReader("isocontent"))
 		})
 		stubInitrdHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -25,15 +25,14 @@ var _ = Describe("ServeHTTP", func() {
 		})
 
 		imageHandler := &ImageHandler{
-			iso:    stubISOHandler,
+			long:   stubISOHandler,
 			initrd: stubInitrdHandler,
-			sem:    semaphore.NewWeighted(100),
 		}
-		server := httptest.NewServer(imageHandler)
+		server := httptest.NewServer(imageHandler.router(100))
 		client := server.Client()
 		defer server.Close()
 
-		resp, err := client.Get(fmt.Sprintf("%s/images/test-image-id", server.URL))
+		resp, err := client.Get(fmt.Sprintf("%s/images/%s", server.URL, imageID))
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -43,25 +42,25 @@ var _ = Describe("ServeHTTP", func() {
 	})
 
 	It("calls the initrd handler ServeHTTP", func() {
+		imageID := "bf25292a-dddd-49dc-ab9c-3fb4c1f07071"
 		stubISOHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			Fail("initrd handler should not have been called")
+			Fail("ISO handler should not have been called")
 		})
 		stubInitrdHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			Expect(r.Method).To(Equal(http.MethodGet))
-			Expect(r.URL.Path).To(Equal("/images/test-image-id/pxe-initrd"))
+			Expect(r.URL.Path).To(Equal(fmt.Sprintf("/images/%s/pxe-initrd", imageID)))
 			http.ServeContent(w, r, "initrd.img", time.Now(), strings.NewReader("initrdcontent"))
 		})
 
 		imageHandler := &ImageHandler{
-			iso:    stubISOHandler,
+			long:   stubISOHandler,
 			initrd: stubInitrdHandler,
-			sem:    semaphore.NewWeighted(100),
 		}
-		server := httptest.NewServer(imageHandler)
+		server := httptest.NewServer(imageHandler.router(100))
 		client := server.Client()
 		defer server.Close()
 
-		resp, err := client.Get(fmt.Sprintf("%s/images/test-image-id/pxe-initrd", server.URL))
+		resp, err := client.Get(fmt.Sprintf("%s/images/%s/pxe-initrd", server.URL, imageID))
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))

--- a/internal/handlers/initrd.go
+++ b/internal/handlers/initrd.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/openshift/assisted-image-service/pkg/imagestore"
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 	"github.com/openshift/assisted-image-service/pkg/overlay"
-	log "github.com/sirupsen/logrus"
 )
 
 type initrdHandler struct {
@@ -20,11 +22,7 @@ type initrdHandler struct {
 var _ http.Handler = &initrdHandler{}
 
 func (h *initrdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	imageID, err := parseImageID(r.URL.Path)
-	if err != nil {
-		httpErrorf(w, http.StatusNotFound, "failed to parse image ID: %v\n", err)
-		return
-	}
+	imageID := chi.URLParam(r, "image_id")
 
 	version := r.URL.Query().Get("version")
 	if version == "" {

--- a/internal/handlers/initrd_test.go
+++ b/internal/handlers/initrd_test.go
@@ -60,10 +60,13 @@ var _ = Describe("ServeHTTP", func() {
 		asc, err := NewAssistedServiceClient(u.Scheme, u.Host, "")
 		Expect(err).NotTo(HaveOccurred())
 
-		server = httptest.NewServer(&initrdHandler{
-			ImageStore: mockImageStore,
-			client:     asc,
-		})
+		handler := &ImageHandler{
+			initrd: &initrdHandler{
+				ImageStore: mockImageStore,
+				client:     asc,
+			},
+		}
+		server = httptest.NewServer(handler.router(1))
 
 		client = server.Client()
 	})

--- a/internal/handlers/iso.go
+++ b/internal/handlers/iso.go
@@ -3,8 +3,6 @@ package handlers
 import (
 	"fmt"
 	"net/http"
-	"net/url"
-	"regexp"
 	"time"
 
 	"github.com/openshift/assisted-image-service/pkg/imagestore"
@@ -16,27 +14,24 @@ type isoHandler struct {
 	ImageStore          imagestore.ImageStore
 	GenerateImageStream isoeditor.StreamGeneratorFunc
 	client              *AssistedServiceClient
+	// second arg is an HTTP response code to use when the error != nil
+	urlParser func(*http.Request) (*imageDownloadParams, int, error)
 }
 
 var _ http.Handler = &isoHandler{}
 
 type imageDownloadParams struct {
+	imageID   string
 	version   string
 	imageType string
 	arch      string
 }
 
 func (h *isoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	imageID, err := parseImageID(r.URL.Path)
-	if err != nil {
-		log.Errorf("failed to parse image ID: %v\n", err)
-		http.NotFound(w, r)
-		return
-	}
+	params, statusCode, err := h.urlParser(r)
 
-	params, err := h.parseQueryParams(r.URL.Query())
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(statusCode)
 		_, err = w.Write([]byte(err.Error()))
 		if err != nil {
 			log.Errorf("Failed to write response: %v\n", err)
@@ -44,7 +39,13 @@ func (h *isoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ignition, lastModified, statusCode, err := h.client.ignitionContent(r, imageID, params.imageType)
+	if !h.ImageStore.HaveVersion(params.version, params.arch) {
+		log.Errorf("version for %s %s, not found", params.version, params.arch)
+		http.NotFound(w, r)
+		return
+	}
+
+	ignition, lastModified, statusCode, err := h.client.ignitionContent(r, params.imageID, params.imageType)
 	if err != nil {
 		log.Errorf("Error retrieving ignition content: %v\n", err)
 		w.WriteHeader(statusCode)
@@ -53,7 +54,7 @@ func (h *isoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var ramdisk []byte
 	if params.imageType == imagestore.ImageTypeMinimal {
-		ramdisk, statusCode, err = h.client.ramdiskContent(r, imageID)
+		ramdisk, statusCode, err = h.client.ramdiskContent(r, params.imageID)
 		if err != nil {
 			log.Errorf("Error retrieving ramdisk content: %v\n", err)
 			w.WriteHeader(statusCode)
@@ -62,7 +63,7 @@ func (h *isoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var kargs []byte
-	kargs, statusCode, err = h.client.discoveryKernelArguments(r, imageID)
+	kargs, statusCode, err = h.client.discoveryKernelArguments(r, params.imageID)
 	if err != nil {
 		log.Errorf("Error retrieving kernel arguments content: %v\n", err)
 		w.WriteHeader(statusCode)
@@ -82,7 +83,7 @@ func (h *isoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer isoReader.Close()
 
-	fileName := fmt.Sprintf("%s-discovery.iso", imageID)
+	fileName := fmt.Sprintf("%s-discovery.iso", params.imageID)
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileName))
 	modTime, err := http.ParseTime(lastModified)
 	if err != nil {
@@ -90,43 +91,4 @@ func (h *isoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		modTime = time.Now()
 	}
 	http.ServeContent(w, r, fileName, modTime, isoReader)
-}
-
-func (h *isoHandler) parseQueryParams(values url.Values) (*imageDownloadParams, error) {
-	version := values.Get("version")
-	if version == "" {
-		return nil, fmt.Errorf("'version' parameter required")
-	}
-
-	arch := values.Get("arch")
-	if arch == "" {
-		arch = defaultArch
-	}
-
-	if !h.ImageStore.HaveVersion(version, arch) {
-		return nil, fmt.Errorf("version for %s %s, not found", version, arch)
-	}
-
-	imageType := values.Get("type")
-	if imageType == "" {
-		return nil, fmt.Errorf("'type' parameter required")
-	} else if imageType != imagestore.ImageTypeFull && imageType != imagestore.ImageTypeMinimal {
-		return nil, fmt.Errorf("invalid value '%s' for parameter 'type'", imageType)
-	}
-
-	return &imageDownloadParams{
-		version:   version,
-		imageType: imageType,
-		arch:      arch,
-	}, nil
-}
-
-var pathRegexp = regexp.MustCompile(`^/images/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(/pxe-initrd)?`)
-
-func parseImageID(path string) (string, error) {
-	match := pathRegexp.FindStringSubmatch(path)
-	if match == nil {
-		return "", fmt.Errorf("malformed download path: %s", path)
-	}
-	return match[1], nil
 }

--- a/internal/handlers/long.go
+++ b/internal/handlers/long.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openshift/assisted-image-service/pkg/imagestore"
+)
+
+// parseLongURL parses the long-style URLs that use query parameters to identify
+// the desired resource. This style of URL is deprecated in favor of short URLs.
+func parseLongURL(r *http.Request) (*imageDownloadParams, int, error) {
+	imageID := chi.URLParam(r, "image_id")
+
+	values := r.URL.Query()
+	version := values.Get("version")
+	if version == "" {
+		return nil, http.StatusBadRequest, fmt.Errorf("'version' parameter required")
+	}
+
+	arch := values.Get("arch")
+	if arch == "" {
+		arch = defaultArch
+	}
+
+	imageType := values.Get("type")
+	if imageType == "" {
+		return nil, http.StatusBadRequest, fmt.Errorf("'type' parameter required")
+	} else if imageType != imagestore.ImageTypeFull && imageType != imagestore.ImageTypeMinimal {
+		return nil, http.StatusBadRequest, fmt.Errorf("invalid value '%s' for parameter 'type'", imageType)
+	}
+
+	return &imageDownloadParams{
+		version:   version,
+		imageType: imageType,
+		arch:      arch,
+		imageID:   imageID,
+	}, 0, nil
+}

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/rs/cors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
 )
 
 func WithCORSMiddleware(handler http.Handler, domains string) http.Handler {
@@ -31,11 +33,6 @@ func WithInitrdViaHTTP(handler http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Check plain HTTP requests
 		if r.TLS == nil {
-			if _, err := parseImageID(r.URL.Path); err != nil {
-				// Invalid UUID format
-				http.NotFound(w, r)
-				return
-			}
 			if !strings.HasSuffix(r.URL.Path, "/pxe-initrd") {
 				// Only "/pxe-initrd" is allowed to be fetched
 				http.NotFound(w, r)
@@ -43,5 +40,26 @@ func WithInitrdViaHTTP(handler http.Handler) http.HandlerFunc {
 			}
 		}
 		handler.ServeHTTP(w, r)
+	}
+}
+
+// WithRequestLimit returns middleware that will limit the number of requests
+// being concurrently handled to maxRequests. Blocks until a slot becomes
+// available. A 503 response will be returned if the context expires or is
+// cancelled while waiting.
+func WithRequestLimit(maxRequests int64) func(http.Handler) http.Handler {
+	sem := semaphore.NewWeighted(maxRequests)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := sem.Acquire(r.Context(), 1); err != nil {
+				log.Errorf("Failed to acquire semaphore: %v", err)
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			defer sem.Release(1)
+
+			next.ServeHTTP(w, r)
+		})
 	}
 }

--- a/internal/handlers/short.go
+++ b/internal/handlers/short.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/go-chi/chi/v5"
+)
+
+var jwtPayloadRegexp = regexp.MustCompile(`^.+\.(.+)\..+`)
+
+type payload struct {
+	Sub        string `json:"sub"`          // used by OCM tokens
+	InfraEnvID string `json:"infra_env_id"` // used by local auth tokens
+}
+
+// parseShortURL parses short-style URLs, where URL path segments are used to
+// hierarchically identify the desired resource. The URL ordering and structure
+// is defined on the router.
+func parseShortURL(r *http.Request) (*imageDownloadParams, int, error) {
+	imageID := chi.URLParam(r, "image_id")
+	token := chi.URLParam(r, "token")
+	if token == "" {
+		// try the "api_key" parameter name, which is used at the /byapikey/ path.
+		token = chi.URLParam(r, "api_key")
+	}
+	version := chi.URLParam(r, "version")
+	arch := chi.URLParam(r, "arch")
+	filename := chi.URLParam(r, "filename")
+
+	var err error
+	// the URL can have either the token or the image_id
+	if imageID == "" {
+		imageID, err = idFromJWT(token)
+		if err != nil {
+			return nil, http.StatusNotFound, err
+		}
+	}
+
+	params := imageDownloadParams{
+		imageID: imageID,
+		version: version,
+		arch:    arch,
+	}
+
+	switch filename {
+	case "minimal.iso":
+		params.imageType = "minimal-iso"
+	case "full.iso":
+		params.imageType = "full-iso"
+	default:
+		return nil, http.StatusNotFound, fmt.Errorf("unrecognized file name %s", filename)
+	}
+
+	return &params, 0, nil
+}
+
+// idFromJWT parses the JWT payload to find the infraenv ID. No signature
+// verification is done here, because we do not need to trust the payload in
+// this service. The JWT will be verified and evaluated for authn and authz by
+// assisted-service.
+func idFromJWT(jwt string) (string, error) {
+	match := jwtPayloadRegexp.FindStringSubmatch(jwt)
+
+	if len(match) != 2 {
+		return "", fmt.Errorf("failed to parse JWT from URL")
+	}
+
+	decoded, err := base64.RawStdEncoding.DecodeString(match[1])
+	if err != nil {
+		return "", err
+	}
+
+	var p payload
+	err = json.Unmarshal(decoded, &p)
+	if err != nil {
+		return "", err
+	}
+
+	switch {
+	case p.Sub != "":
+		return p.Sub, nil
+	case p.InfraEnvID != "":
+		return p.InfraEnvID, nil
+	}
+
+	return "", fmt.Errorf("InfraEnv ID not found in token")
+}

--- a/internal/handlers/short_test.go
+++ b/internal/handlers/short_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Parse short URLs", func() {
+	var (
+		imageID = "bf25292a-dddd-49dc-ab9c-3fb4c1f07071"
+
+		// generated at https://jwt.io/ with payload:
+		//
+		//	{
+		//		"infra_env_id": "bf25292a-dddd-49dc-ab9c-3fb4c1f07071"
+		//	}
+		tokenInfraEnv = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpbmZyYV9lbnZfaWQiOiJiZjI1MjkyYS1kZGRkLTQ5ZGMtYWI5Yy0zZmI0YzFmMDcwNzEifQ.VbI4JtIVcxy2S7n2tYFgtFPD9St15RrzQnpJuE0CuAI" //#nosec
+
+		// generated at https://jwt.io/ with payload:
+		//
+		//	{
+		//		"sub": "bf25292a-dddd-49dc-ab9c-3fb4c1f07071"
+		//	}
+		tokenSub = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpbmZyYV9lbnZfaWQiOiJiZjI1MjkyYS1kZGRkLTQ5ZGMtYWI5Yy0zZmI0YzFmMDcwNzEifQ.VbI4JtIVcxy2S7n2tYFgtFPD9St15RrzQnpJuE0CuAI" //#nosec
+
+		// generated at https://jwt.io/ with payload:
+		//
+		//	{
+		//	 	"name": "John Doe"
+		//	}
+		tokenNoID = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.DjwRE2jZhren2Wt37t5hlVru6Myq4AhpGLiiefF69u8" //#nosec
+	)
+
+	Describe("idFromJWT tests", func() {
+		It("succeeds with a  JWT with infra env ID", func() {
+			value, err := idFromJWT(tokenInfraEnv)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal(imageID))
+		})
+
+		It("succeeds with a JWT with sub ID", func() {
+			value, err := idFromJWT(tokenSub)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal(imageID))
+		})
+
+		It("returns an error when parsing an invalid JWT", func() {
+			_, err := idFromJWT("not a JWT")
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error when parsing a JWT that can't be base64 decoded", func() {
+			_, err := idFromJWT("foo.bar.baz")
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error when parsing a JWT with no ID", func() {
+			_, err := idFromJWT(tokenNoID)
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("parseShortURL tests", func() {
+		It("200 if infra_env_id present in token", func() {
+			r := requestWithKeys(tokenInfraEnv, "", "4.12", "x86_64", "full.iso")
+
+			params, _, err := parseShortURL(r)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(params.imageID).To(Equal(imageID))
+			Expect(params.version).To(Equal("4.12"))
+			Expect(params.arch).To(Equal("x86_64"))
+		})
+		It("200 if sub present in token", func() {
+			r := requestWithKeys(tokenSub, "", "4.12", "x86_64", "full.iso")
+
+			params, _, err := parseShortURL(r)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(params.imageID).To(Equal(imageID))
+			Expect(params.version).To(Equal("4.12"))
+			Expect(params.arch).To(Equal("x86_64"))
+		})
+		It("200 if imageID present in URL", func() {
+			r := requestWithKeys("", imageID, "4.12", "x86_64", "minimal.iso")
+
+			params, _, err := parseShortURL(r)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(params.imageID).To(Equal(imageID))
+			Expect(params.version).To(Equal("4.12"))
+			Expect(params.arch).To(Equal("x86_64"))
+		})
+		It("404 if image ID not present in token", func() {
+			r := requestWithKeys(tokenNoID, "", "4.12", "x86_64", "full.iso")
+
+			_, code, err := parseShortURL(r)
+
+			Expect(code).To(Equal(http.StatusNotFound))
+			Expect(err).To(HaveOccurred())
+		})
+		It("404 if file name not recognized", func() {
+			r := requestWithKeys(tokenNoID, "", "4.12", "x86_64", "entire.iso")
+
+			_, code, err := parseShortURL(r)
+
+			Expect(code).To(Equal(http.StatusNotFound))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+func requestWithKeys(token, imageID, version, arch, filename string) *http.Request {
+	url := ""
+	rctx := chi.NewRouteContext()
+	if token != "" {
+		url = fmt.Sprintf("https://example.redhat.com/bytoken/%s/%s/%s/%s", token, version, arch, filename)
+		rctx.URLParams.Add("token", token)
+	}
+	if imageID != "" {
+		url = fmt.Sprintf("https://example.redhat.com/byid/%s/%s/%s/%s", imageID, version, arch, filename)
+		rctx.URLParams.Add("image_id", imageID)
+	}
+	rctx.URLParams.Add("version", version)
+	rctx.URLParams.Add("arch", arch)
+	rctx.URLParams.Add("filename", filename)
+	r := httptest.NewRequest(http.MethodGet, url, strings.NewReader(""))
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}

--- a/main.go
+++ b/main.go
@@ -128,6 +128,9 @@ func main() {
 		imageHandler = handlers.WithInitrdViaHTTP(imageHandler)
 	}
 	http.Handle("/images/", imageHandler)
+	http.Handle("/byapikey/", imageHandler)
+	http.Handle("/byid/", imageHandler)
+	http.Handle("/bytoken/", imageHandler)
 
 	serverInfo.ListenAndServe()
 	<-stop


### PR DESCRIPTION
## Description

Implements the [Short Image URL
enhancement](https://github.com/openshift/assisted-service/blob/master/docs/enhancements/short-url-enhancement.md).

Quoting the enhancement summary: "The assisted-image-service should be enhanced to serve discovery ISOs from URLs that are less than 255 characters and don't have query parameters. This will enable servers from multiple vendors to directly boot from an assisted-image-service URL using the baseboard management controller."


## How was this code tested?
by hand and with new automated tests


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/assign @carbonin 


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
