### PR TITLE
Allow kernel downloads for s390x architecture

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -83,25 +83,25 @@ parameters:
       {
         "openshift_version": "4.13",
         "cpu_architecture": "x86_64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest-4.13/rhcos-4.13.0-ec.3-x86_64-live.x86_64.iso",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.13.0-rc.2/rhcos-4.13.0-rc.2-x86_64-live.x86_64.iso",
         "version": "413.86.202302162343-0"
       },
       {
         "openshift_version": "4.13",
         "cpu_architecture": "arm64",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/latest-4.13/rhcos-4.13.0-ec.3-aarch64-live.aarch64.iso",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/4.13.0-rc.2/rhcos-4.13.0-rc.2-aarch64-live.aarch64.iso",
         "version": "413.86.202302162338-0"
       },
       {
         "openshift_version": "4.13",
         "cpu_architecture": "ppc64le",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/pre-release/latest-4.13/rhcos-4.13.0-ec.3-ppc64le-live.ppc64le.iso",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/pre-release/4.13.0-rc.2/rhcos-4.13.0-rc.2-ppc64le-live.ppc64le.iso",
         "version": "413.86.202302162338-0"
       },
       {
         "openshift_version": "4.13",
         "cpu_architecture": "s390x",
-        "url": "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/pre-release/latest-4.13/rhcos-4.13.0-ec.3-s390x-live.s390x.iso",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/pre-release/4.13.0-rc.2/rhcos-4.13.0-rc.2-s390x-live.s390x.iso",
         "version": "413.86.202302162339-0"
       }
     ]

--- a/internal/handlers/boot_artifacts_test.go
+++ b/internal/handlers/boot_artifacts_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-image-service/pkg/imagestore"
 )
@@ -118,7 +119,7 @@ var _ = Describe("ServeHTTP", func() {
 		It("fails when non-existent artifact is supplied", func() {
 			resp, err := client.Get(server.URL + "/boot-artifacts/")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 		})
 
 		It("fails for unsupported methods", func() {
@@ -129,3 +130,20 @@ var _ = Describe("ServeHTTP", func() {
 		})
 	})
 })
+
+var _ = DescribeTable("parseArtifact",
+	func(path, arch, artifact string, success bool) {
+		a, err := parseArtifact(path, arch)
+		if success {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(a).To(Equal(artifact))
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+	},
+	Entry("returns rootfs correctly", "/boot-artifacts/rootfs", "x86_64", "rootfs.img", true),
+	Entry("returns kernel correctly", "/boot-artifacts/kernel", "x86_64", "vmlinuz", true),
+	Entry("returns s390x kernel correctly", "/boot-artifacts/kernel", "s390x", "kernel.img", true),
+	Entry("fails for an invalid artifact", "/boot-artifacts/asdf", "x86_64", "", false),
+	Entry("fails for an incorrect path", "/wrong-path/rootfs", "x86_64", "", false),
+)


### PR DESCRIPTION
## Description

The s390x ISO kernel is at `/images/pxeboot/kernel.img` instead of `/images/pxeboot/vmlinuz`. This PR accounts for that difference.

It also updates the template to reference existing URLs for the 4.13 images since I noticed these were wrong when trying to find an image to test with.

## How was this code tested?
Ran the new image locally and verified that the kernel downloads correctly.

## Assignees

/cc @CrystalChun 
/cc @danielerez 
/cc @jaypoulz 
/cc @jacobemery 

## Links
<!--
List any applicable links to related PRs or issues
-->

https://issues.redhat.com/browse/MGMT-13716

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
