### PR TITLE
MGMT-14370: add initial live-iso images for 4.14

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -103,6 +103,30 @@ parameters:
         "cpu_architecture": "s390x",
         "url": "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/pre-release/4.13.0-rc.2/rhcos-4.13.0-rc.2-s390x-live.s390x.iso",
         "version": "413.86.202302162339-0"
+      },
+      {
+        "openshift_version": "4.14",
+        "cpu_architecture": "x86_64",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.13.0-rc.2/rhcos-4.13.0-rc.2-x86_64-live.x86_64.iso",
+        "version": "413.92.202303281804-0"
+      },
+      {
+        "openshift_version": "4.14",
+        "cpu_architecture": "arm64",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/4.13.0-rc.2/rhcos-4.13.0-rc.2-aarch64-live.aarch64.iso",
+        "version": "413.92.202303281804-0"
+      },
+      {
+        "openshift_version": "4.14",
+        "cpu_architecture": "ppc64le",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/pre-release/4.13.0-rc.2/rhcos-4.13.0-rc.2-ppc64le-live.ppc64le.iso",
+        "version": "413.92.202303281804-0"
+      },
+      {
+        "openshift_version": "4.14",
+        "cpu_architecture": "s390x",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/pre-release/4.13.0-rc.2/rhcos-4.13.0-rc.2-s390x-live.s390x.iso",
+        "version": "413.92.202303281804-0"
       }
     ]
   required: false


### PR DESCRIPTION
This clones the entries for OCP 4.13 images to OCP 4.14, as there are no officially released 4.14 images.

The actual effect of this PR is only for the integration system which uses the default value of ``OS_IMAGES`` (test-infra automation uses the configuration in ``assisted-service`` repo).

## How was this code tested?

I need to check if we're within the PVC capacity. Other than that, I'll verify installation works with those images locally.

/hold

## Assignees

/cc @carbonin 
/cc @gamli75 

## Links

https://issues.redhat.com/browse/MGMT-14370

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
