### PR TITLE
[WIP] MGMT-13692: Use the ignition file info

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -31,22 +31,52 @@ import (
 var (
 	versions = []map[string]string{
 		{
-			"openshift_version": "pre-release",
+			"openshift_version": "pre-release-arm",
 			"cpu_architecture":  "arm64",
 			"url":               "https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/pre-release/latest/rhcos-live.aarch64.iso",
+			"version":           "arm-pre",
+		},
+		{
+			"openshift_version": "pre-release-x86",
+			"cpu_architecture":  "x86_64",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest/rhcos-live.x86_64.iso",
+			"version":           "x86_64-pre",
+		},
+		{
+			"openshift_version": "pre-release-Z",
+			"cpu_architecture":  "s390x",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/pre-release/latest/rhcos-live.s390x.iso",
+			"version":           "s390x-pre",
+		},
+		{
+			"openshift_version": "pre-release-power",
+			"cpu_architecture":  "ppc64le",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/pre-release/latest/rhcos-live.ppc64le.iso",
+			"version":           "ppc64le-pre",
+		},
+		{
+			"openshift_version": "latest-arm",
+			"cpu_architecture":  "arm64",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/latest/rhcos-live.aarch64.iso",
 			"version":           "arm-latest",
 		},
 		{
-			"openshift_version": "4.8",
+			"openshift_version": "latest-x86",
 			"cpu_architecture":  "x86_64",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.8/latest/rhcos-live.x86_64.iso",
-			"version":           "4.8-latest",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/latest/rhcos-live.x86_64.iso",
+			"version":           "x86_64-latest",
 		},
 		{
-			"openshift_version": "pre-release",
-			"cpu_architecture":  "x86_64",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.10.0-rc.0/rhcos-live.x86_64.iso",
-			"version":           "x86_64-latest",
+			"openshift_version": "latest-Z",
+			"cpu_architecture":  "s390x",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/latest/rhcos-live.s390x.iso",
+			"version":           "s390x-latest",
+		},
+		{
+			"openshift_version": "latest-power",
+			"cpu_architecture":  "ppc64le",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/latest/rhcos-live.ppc64le.iso",
+			"version":           "ppc64le-latest",
 		},
 		{
 			"openshift_version": "fcos-pre-release",
@@ -59,18 +89,6 @@ var (
 			"cpu_architecture":  "arm64",
 			"url":               "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live.aarch64.iso",
 			"version":           "arm-latest",
-		},
-		{
-			"openshift_version": "4.11",
-			"cpu_architecture":  "s390x",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-s390x-live.s390x.iso",
-			"version":           "s390x-latest",
-		},
-		{
-			"openshift_version": "4.11",
-			"cpu_architecture":  "ppc64le",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-ppc64le-live.ppc64le.iso",
-			"version":           "ppc64le-latest",
 		},
 		{
 			"openshift_version": "scos-prerelease",
@@ -235,6 +253,7 @@ var _ = Describe("Image integration tests", func() {
 					fs, err := d.GetFilesystem(0)
 					Expect(err).NotTo(HaveOccurred())
 
+					// TODO: Do this correctly based on the presence of /coreos/igninfo.json
 					By("verifying ignition content")
 					f, err := fs.OpenFile("/images/ignition.img", os.O_RDONLY)
 					Expect(err).NotTo(HaveOccurred())

--- a/pkg/isoeditor/isoeditor_suite_test.go
+++ b/pkg/isoeditor/isoeditor_suite_test.go
@@ -32,6 +32,12 @@ label linux
 ###################### COREOS_KARG_EMBED_AREA
 `
 
+const testIgnitionInfo = `
+{
+  "file": "images/ignition.img"
+}
+`
+
 const ignitionPaddingLength = 256 * 1024 // 256KB
 
 func createTestFiles(volumeID string) (string, string) {
@@ -45,6 +51,7 @@ func createTestFiles(volumeID string) (string, string) {
 	Expect(temp.Close()).To(Succeed())
 	Expect(os.Remove(temp.Name())).To(Succeed())
 
+	Expect(os.MkdirAll(filepath.Join(filesDir, "coreos"), 0755)).To(Succeed())
 	Expect(os.MkdirAll(filepath.Join(filesDir, "images/pxeboot"), 0755)).To(Succeed())
 	Expect(os.MkdirAll(filepath.Join(filesDir, "EFI/redhat"), 0755)).To(Succeed())
 	Expect(os.MkdirAll(filepath.Join(filesDir, "isolinux"), 0755)).To(Succeed())
@@ -57,6 +64,7 @@ func createTestFiles(volumeID string) (string, string) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(f.Truncate(64)).To(Succeed())
 
+	Expect(os.WriteFile(filepath.Join(filesDir, "coreos/igninfo.json"), []byte(testIgnitionInfo), 0600)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/assisted_installer_custom.img"), make([]byte, RamDiskPaddingLength), 0600)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/ignition.img"), make([]byte, ignitionPaddingLength), 0600)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/pxeboot/rootfs.img"), []byte("this is rootfs"), 0600)).To(Succeed())

--- a/pkg/isoeditor/stream.go
+++ b/pkg/isoeditor/stream.go
@@ -29,13 +29,13 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 		return nil, err
 	}
 
-	r, err := readerForFileContent(isoPath, ignitionImagePath, isoReader, ignitionReader)
+	r, err := readerForContent(isoPath, ignitionImagePath, isoReader, ignitionReader, GetISOFileInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create overwrite reader for ignition")
 	}
 
 	if ramdiskContent != nil {
-		r, err = readerForFileContent(isoPath, ramDiskImagePath, r, bytes.NewReader(ramdiskContent))
+		r, err = readerForContent(isoPath, ramDiskImagePath, r, bytes.NewReader(ramdiskContent), GetISOFileInfo)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create overwrite reader for ramdisk")
 		}
@@ -78,8 +78,4 @@ func readerForContent(isoPath, filePath string, base io.ReadSeeker, contentReade
 	}
 
 	return r, nil
-}
-
-func readerForFileContent(isoPath string, filePath string, base io.ReadSeeker, contentReader *bytes.Reader) (overlay.OverlayReader, error) {
-	return readerForContent(isoPath, filePath, base, contentReader, GetISOFileInfo)
 }

--- a/pkg/isoeditor/stream.go
+++ b/pkg/isoeditor/stream.go
@@ -2,6 +2,7 @@ package isoeditor
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -11,12 +12,19 @@ import (
 )
 
 const ignitionImagePath = "/images/ignition.img"
+const ignitionInfoPath = "/coreos/igninfo.json"
 
 type ImageReader = overlay.OverlayReader
 
 type BoundariesFinder func(filePath, isoPath string) (int64, int64, error)
 
 type StreamGeneratorFunc func(isoPath string, ignitionContent *IgnitionContent, ramdiskContent, kargs []byte) (ImageReader, error)
+
+type ignitionInfo struct {
+	File   string `json:"file,omitempty"`
+	Length int64  `json:"length,omitempty"`
+	Offset int64  `json:"offset,omitempty"`
+}
 
 func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte, kargs []byte) (ImageReader, error) {
 	isoReader, err := os.Open(isoPath)
@@ -29,7 +37,7 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 		return nil, err
 	}
 
-	r, err := readerForContent(isoPath, ignitionImagePath, isoReader, ignitionReader, GetISOFileInfo)
+	r, err := readerForContent(isoPath, ignitionImagePath, isoReader, ignitionReader, ignitionBoundariesFinder)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create overwrite reader for ignition")
 	}
@@ -55,6 +63,34 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 	}
 
 	return r, nil
+}
+
+func ignitionBoundariesFinder(filePath, isoPath string) (int64, int64, error) {
+	ignitionInfoData, err := ReadFileFromISO(isoPath, ignitionInfoPath)
+	// If the igninfo.json file doesn't exist or we fail to access it, fall back to using the given ignition file
+	// This will be the case for earlier versions of RHCOS
+	if err != nil {
+		return GetISOFileInfo(filePath, isoPath)
+	}
+
+	info := &ignitionInfo{}
+	err = json.Unmarshal(ignitionInfoData, info)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	isoFileOffset, isoFileLength, err := GetISOFileInfo(info.File, isoPath)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// use the entire file offset and length if they are not specified in the info struct
+	if info.Length == 0 && info.Offset == 0 {
+		return isoFileOffset, isoFileLength, nil
+	}
+
+	// the final offset is the file offset within the ISO plus the offset within the file
+	return isoFileOffset + info.Offset, info.Length, nil
 }
 
 func readerForContent(isoPath, filePath string, base io.ReadSeeker, contentReader *bytes.Reader, boundariesFinder BoundariesFinder) (overlay.OverlayReader, error) {


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

If the ignition info file (/coreos/igninfo.json) is present in the ISO
use it to determine where the ignition content should be embedded
instead of assuming it should always go in "/images/ignition.img"

If an error is encountered when reading the ignition info, fall back to
the previous ignition path. This allows the image service to seamlessly
support older versions without having to explicitly include logic about
which version is being used in every call.


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

Added a failing test in the integration tests (s390x pre-release).
This should be fixed before merging.

I'm not sure if it's worth adding separate unit-tests for with or without this file.
For now maybe we should pin a single integration test to a version without it? I'm not sure.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @ori-amizur 

## Links
<!--
List any applicable links to related PRs or issues
-->

Resolves https://issues.redhat.com/browse/MGMT-13692

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
