### PR TITLE
MGMT-15822: use Dockerfiles of head commit

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-9-release-golang-1.20-openshift-4.14


### PR DESCRIPTION
This enables building the build-root image from the HEAD commit instead of base commit, meaning PRs changing Dockerfiles are tested including their Dockerfile changes.

This is a preliminary stage for moving to stream9 U/S, as it makes testing much easier.

## How was this code tested?

This can only be tested in the followup PR to ``openshift/release``.

## Assignees

/cc @eliorerz 
/cc @gamli75 

## Links
https://issues.redhat.com/browse/MGMT-15822

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
