### PR TITLE
MGMT-15822: change base image to stream9

### DIFF
--- a/Dockerfile.image-service
+++ b/Dockerfile.image-service
@@ -6,7 +6,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o /assisted-image-service main.go
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 ARG DATA_DIR=/data
 RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR


### PR DESCRIPTION
## Description

Now that D/S building system fully supports RHEL-9 base images (and allows easy installation of nmstate and other libs that were previously unsupported) we can move U/S to stream9 and D/S to ubi9-minimal.

It doesn't seem possible to easily use ubi9-minimal U/S for the assisted-service, because installation of nmstate packages either requires entitlements running on a RHEL node, or alternatively an access to RedHat's internal network (which can be a major problem for U/S development). For a better consistency we're sticking with the same for the agent, installer, etc.

## How was this code tested?

CI will do the tests.

## Assignees

TBD

## Links

https://issues.redhat.com/browse/MGMT-15822


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
