### PR TITLE
OCPBUGS-22427: Use 'igninfo.json' to find ignition location

### DIFF
--- a/pkg/isoeditor/isoeditor_suite_test.go
+++ b/pkg/isoeditor/isoeditor_suite_test.go
@@ -1,6 +1,8 @@
 package isoeditor
 
 import (
+	"crypto/rand"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -68,4 +70,74 @@ func createTestFiles(volumeID string) (string, string) {
 	Expect(cmd.Run()).To(Succeed())
 
 	return filesDir, isoFile
+}
+
+// createS390TestFiles creates an ISO that resembles the ones used for the S390 architecture, in
+// particular it contains a '/coreos/inginfo.json' file that indicates that the ignition is
+// embedded in the '/images/cdboot.img' file instead of the usual location '/images/ignition.img'.
+func createS390TestFiles(volumeID string) (tmpDir string, isoFile string) {
+	// Create a temporary directory:
+	tmpDir, err := os.MkdirTemp("", "isotest")
+	Expect(err).ToNot(HaveOccurred())
+
+	// Create a temporary file for the ISO:
+	isoFd, err := os.CreateTemp("", "*test.iso")
+	Expect(err).ToNot(HaveOccurred())
+	isoFile = isoFd.Name()
+	Expect(isoFd.Close()).To(Succeed())
+	Expect(os.Remove(isoFile)).To(Succeed())
+
+	// Create the '/images' directoy:
+	imagesDir := filepath.Join(tmpDir, "images")
+	Expect(os.MkdirAll(imagesDir, 0755)).To(Succeed())
+
+	// Create the '/images/cdboot.img' file containing a random prefix, the ignition data, and
+	// a random suffix. The random prefix and suffix are intended to make things crash loudly
+	// if the code tries to read and parse that as JSON.
+	cdBootFile := filepath.Join(imagesDir, "cdboot.img")
+	cdBootFd, err := os.OpenFile(cdBootFile, os.O_CREATE|os.O_WRONLY, 0600)
+	Expect(err).ToNot(HaveOccurred())
+	randomPrefix := make([]byte, 4096)
+	_, err = rand.Read(randomPrefix)
+	Expect(err).ToNot(HaveOccurred())
+	randomSuffix := make([]byte, 4096)
+	_, err = rand.Read(randomSuffix)
+	Expect(err).ToNot(HaveOccurred())
+	ignitionBytes := make([]byte, ignitionPaddingLength)
+	_, err = cdBootFd.Write(randomPrefix)
+	Expect(err).ToNot(HaveOccurred())
+	_, err = cdBootFd.Write(ignitionBytes)
+	Expect(err).ToNot(HaveOccurred())
+	_, err = cdBootFd.Write(randomSuffix)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cdBootFd.Close()).To(Succeed())
+
+	// Create the '/coreos' directory:
+	coreosDir := filepath.Join(tmpDir, "coreos")
+	Expect(os.MkdirAll(coreosDir, 0755)).To(Succeed())
+
+	// Create the '/coreos/igninfo.json' file:
+	ignInf := IgnInfo{
+		File:   "images/cdboot.img",
+		Offset: int64(len(randomPrefix)),
+		Length: ignitionPaddingLength,
+	}
+	ignInfData, err := json.Marshal(ignInf)
+	Expect(err).ToNot(HaveOccurred())
+	ignInfFile := filepath.Join(coreosDir, "igninfo.json")
+	Expect(os.WriteFile(ignInfFile, ignInfData, 0600)).To(Succeed())
+
+	// Create the ISO:
+	cmd := exec.Command(
+		"genisoimage",
+		"-rational-rock",
+		"-J",
+		"-joliet-long",
+		"-V", volumeID,
+		"-o", isoFile,
+		tmpDir,
+	)
+	Expect(cmd.Run()).To(Succeed())
+
+	return tmpDir, isoFile
 }

--- a/pkg/isoeditor/stream.go
+++ b/pkg/isoeditor/stream.go
@@ -2,21 +2,39 @@ package isoeditor
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/openshift/assisted-image-service/pkg/overlay"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
-const ignitionImagePath = "/images/ignition.img"
+const (
+	ignitionInfoPath         = "/coreos/igninfo.json"
+	defaultIgnitionImagePath = "/images/ignition.img"
+)
 
 type ImageReader = overlay.OverlayReader
 
 type BoundariesFinder func(filePath, isoPath string) (int64, int64, error)
 
 type StreamGeneratorFunc func(isoPath string, ignitionContent *IgnitionContent, ramdiskContent, kargs []byte) (ImageReader, error)
+
+// IgnInfo us used to read and write the content of the '/coreos/igninfo.json' file that indicates
+// the location of the ignition configuration inside the ISO.
+type IgnInfo struct {
+	// File is the absolute path of the file containing the ignition configuration.
+	File string `json:"file"`
+
+	// Offset is the offset of the ignition configuration file within the file.
+	Offset int64 `json:"offset,omitempty"`
+
+	// Length is the length of the ignition configuration.
+	Length int64 `json:"length,omitempty"`
+}
 
 func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte, kargs []byte) (ImageReader, error) {
 	isoReader, err := os.Open(isoPath)
@@ -29,7 +47,69 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 		return nil, err
 	}
 
-	r, err := readerForFileContent(isoPath, ignitionImagePath, isoReader, ignitionReader)
+	// Starting with version 0.17.0 of the CoreOS installer a new '/coreos/igninfo.json' file may
+	// exist to indicate the location of the ignition inside the ISO. For example, in the S390
+	// platform it will contain something like this:
+	//
+	//	{
+	//		"file": "images/cdboot.img",
+	//		"offset": 66497660,
+	//		"length": 262144
+	//	}
+	//
+	// If it exists we need to read it, otherwise we can use the '/images/ignition.img' location
+	// used in previous versions.
+	var ignInfo IgnInfo
+	ignInfoBytes, err := ReadFileFromISO(isoPath, ignitionInfoPath)
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"iso":     isoPath,
+			"file":    ignitionInfoPath,
+			"default": defaultIgnitionImagePath,
+		}).Info(
+			"Failed to read ignition information file, will assume that it doesn't exist " +
+				"and use the default ignition location",
+		)
+		ignInfo.File = defaultIgnitionImagePath
+		ignInfo.Offset = 0
+		_, ignInfo.Length, err = GetISOFileInfo(defaultIgnitionImagePath, isoPath)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err = json.Unmarshal(ignInfoBytes, &ignInfo)
+		if err != nil {
+			return nil, errors.Wrapf(
+				err,
+				"failed to unmarshal ignition information from file '%s' of ISO '%s'",
+				ignitionInfoPath, isoPath,
+			)
+		}
+	}
+
+	// We know now the offset and length of the ignition inside the file that contains it, but
+	// we need to calculate the offset inside the ISO, and for that we need the offset and
+	// length of that container.
+	containerOffset, containerLength, err := GetISOFileInfo(ignInfo.File, isoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// When the length of the ignition is not explicitly specified it is the total length of the
+	// container file:
+	if ignInfo.Length == 0 {
+		ignInfo.Length = containerLength
+	}
+
+	// Create a boundaries finder that calculates the location of the ignition relative to the
+	// complete ISO file:
+	ignBoundariesFinder := func(filePath, isoPath string) (ignOffset int64, ignLength int64, err error) {
+		ignOffset = containerOffset + ignInfo.Offset
+		ignLength = ignInfo.Length
+		return
+	}
+
+	r, err := readerForContent(isoPath, ignInfo.File, isoReader, ignitionReader, ignBoundariesFinder)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create overwrite reader for ignition")
 	}

--- a/pkg/isoeditor/stream_test.go
+++ b/pkg/isoeditor/stream_test.go
@@ -2,6 +2,7 @@ package isoeditor
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 
@@ -63,7 +64,7 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 		Expect(f.Sync()).To(Succeed())
 		Expect(f.Close()).To(Succeed())
 
-		Expect(isoFileContent(f.Name(), ignitionImagePath)).To(Equal(ignitionArchiveBytes))
+		Expect(isoFileContent(f.Name(), defaultIgnitionImagePath)).To(Equal(ignitionArchiveBytes))
 	})
 
 	It("embeds the ignition and ramdisk content", func() {
@@ -78,7 +79,7 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 		Expect(f.Sync()).To(Succeed())
 		Expect(f.Close()).To(Succeed())
 
-		Expect(isoFileContent(f.Name(), ignitionImagePath)).To(Equal(ignitionArchiveBytes))
+		Expect(isoFileContent(f.Name(), defaultIgnitionImagePath)).To(Equal(ignitionArchiveBytes))
 		Expect(isoFileContent(f.Name(), ramDiskImagePath)).To(Equal(initrdContent))
 	})
 	It("embeds the ignition and kargs content", func() {
@@ -93,11 +94,52 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 		Expect(f.Sync()).To(Succeed())
 		Expect(f.Close()).To(Succeed())
 
-		Expect(isoFileContent(f.Name(), ignitionImagePath)).To(Equal(ignitionArchiveBytes))
+		Expect(isoFileContent(f.Name(), defaultIgnitionImagePath)).To(Equal(ignitionArchiveBytes))
 		grubFileContent := string(isoFileContent(f.Name(), defaultGrubFilePath))
 		isolinuxContent := string(isoFileContent(f.Name(), defaultIsolinuxFilePath))
 		for _, content := range []string{grubFileContent, isolinuxContent} {
 			Expect(content).To(MatchRegexp(string(kargs) + "#+ COREOS_KARG_EMBED_AREA"))
 		}
+	})
+
+	It("Embeds the ignition in a ISO that uses the 'igninfo.json' file", func() {
+		// Create input ISO:
+		tmpDir, inputFile := createS390TestFiles("Assisted123")
+		defer func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+			Expect(os.Remove(inputFile)).To(Succeed())
+		}()
+
+		// Copy the output ISO to a file:
+		outputReader, err := NewRHCOSStreamReader(inputFile, &IgnitionContent{ignitionContent}, nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			Expect(outputReader.Close()).To(Succeed())
+		}()
+		outputFd, err := os.CreateTemp(tmpDir, "streamed*.iso")
+		Expect(err).ToNot(HaveOccurred())
+		defer func() {
+			Expect(outputFd.Close()).To(Succeed())
+			Expect(os.Remove(outputFd.Name())).To(Succeed())
+		}()
+		_, err = io.Copy(outputFd, outputReader)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(outputFd.Sync()).To(Succeed())
+
+		// Read the 'igninfo.json' file:
+		ignInfoBytes, err := ReadFileFromISO(inputFile, ignitionInfoPath)
+		Expect(err).ToNot(HaveOccurred())
+		var ignInfo IgnInfo
+		Expect(json.Unmarshal(ignInfoBytes, &ignInfo)).To(Succeed())
+
+		// Read the ignition content. Note that this will read the complete content of the
+		// area containing the ignition content, including the trailing zeros. We need to
+		// remove those before comparing to the input ignition.
+		containerBytes := isoFileContent(outputFd.Name(), ignInfo.File)
+		ignitionBytes := containerBytes[ignInfo.Offset : ignInfo.Offset+ignInfo.Length]
+		ignitionBytes = bytes.TrimRight(ignitionBytes, "\x00")
+
+		// Compare the actual ignition from the ISO with the input:
+		Expect(ignitionBytes).To(Equal(ignitionArchiveBytes))
 	})
 })


### PR DESCRIPTION
## Description

Since version 0.17.0 of the CoreOS installer there is a new `/coreos/igninfo.json` file that indicates the location of the ignition configuration inside the ISO. For example, for version 4.14 the S390 live ISO contains this:

```json
{
  "file": "images/cdboot.img",
  "length": 262144,
  "offset": 66497660
}
```

But we currently ignore this file and expect the ignition configuration always in `/images/ignition.img`, and therefore we fail for these S390 live ISO.

This patch changes the service so that it always looks for the `igninfo.json` file. If it exists it will use the location it indicates, if it doesn't exist it will use the default location.

## How was this code tested?

Tested with the included unit tests.

## Assignees

/cc @gamli75 

## Links

Related: https://issues.redhat.com/browse/OCPBUGS-22427
Related: https://github.com/coreos/coreos-installer/releases/tag/v0.17.0

## Checklist

- [X] Title and description added to both, commit and PR
- [X] Relevant issues have been associated
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit tests (note that code changes require unit tests)
