### PR TITLE
MGMT-13692: Use ignition info

### DIFF
--- a/pkg/isoeditor/isoeditor_suite_test.go
+++ b/pkg/isoeditor/isoeditor_suite_test.go
@@ -32,6 +32,12 @@ label linux
 ###################### COREOS_KARG_EMBED_AREA
 `
 
+const testIgnitionInfo = `
+{
+  "file": "images/ignition.img"
+}
+`
+
 const ignitionPaddingLength = 256 * 1024 // 256KB
 
 func createTestFiles(volumeID string) (string, string) {
@@ -45,6 +51,7 @@ func createTestFiles(volumeID string) (string, string) {
 	Expect(temp.Close()).To(Succeed())
 	Expect(os.Remove(temp.Name())).To(Succeed())
 
+	Expect(os.MkdirAll(filepath.Join(filesDir, "coreos"), 0755)).To(Succeed())
 	Expect(os.MkdirAll(filepath.Join(filesDir, "images/pxeboot"), 0755)).To(Succeed())
 	Expect(os.MkdirAll(filepath.Join(filesDir, "EFI/redhat"), 0755)).To(Succeed())
 	Expect(os.MkdirAll(filepath.Join(filesDir, "isolinux"), 0755)).To(Succeed())
@@ -57,6 +64,7 @@ func createTestFiles(volumeID string) (string, string) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(f.Truncate(64)).To(Succeed())
 
+	Expect(os.WriteFile(filepath.Join(filesDir, "coreos/igninfo.json"), []byte(testIgnitionInfo), 0600)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/assisted_installer_custom.img"), make([]byte, RamDiskPaddingLength), 0600)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/ignition.img"), make([]byte, ignitionPaddingLength), 0600)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/pxeboot/rootfs.img"), []byte("this is rootfs"), 0600)).To(Succeed())

--- a/pkg/isoeditor/stream.go
+++ b/pkg/isoeditor/stream.go
@@ -29,13 +29,13 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 		return nil, err
 	}
 
-	r, err := readerForFileContent(isoPath, ignitionImagePath, isoReader, ignitionReader)
+	r, err := readerForContent(isoPath, ignitionImagePath, isoReader, ignitionReader, GetISOFileInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create overwrite reader for ignition")
 	}
 
 	if ramdiskContent != nil {
-		r, err = readerForFileContent(isoPath, ramDiskImagePath, r, bytes.NewReader(ramdiskContent))
+		r, err = readerForContent(isoPath, ramDiskImagePath, r, bytes.NewReader(ramdiskContent), GetISOFileInfo)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create overwrite reader for ramdisk")
 		}
@@ -78,8 +78,4 @@ func readerForContent(isoPath, filePath string, base io.ReadSeeker, contentReade
 	}
 
 	return r, nil
-}
-
-func readerForFileContent(isoPath string, filePath string, base io.ReadSeeker, contentReader *bytes.Reader) (overlay.OverlayReader, error) {
-	return readerForContent(isoPath, filePath, base, contentReader, GetISOFileInfo)
 }

--- a/pkg/isoeditor/stream.go
+++ b/pkg/isoeditor/stream.go
@@ -2,6 +2,7 @@ package isoeditor
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -11,12 +12,19 @@ import (
 )
 
 const ignitionImagePath = "/images/ignition.img"
+const ignitionInfoPath = "/coreos/igninfo.json"
 
 type ImageReader = overlay.OverlayReader
 
 type BoundariesFinder func(filePath, isoPath string) (int64, int64, error)
 
 type StreamGeneratorFunc func(isoPath string, ignitionContent *IgnitionContent, ramdiskContent, kargs []byte) (ImageReader, error)
+
+type ignitionInfo struct {
+	File   string `json:"file,omitempty"`
+	Length int64  `json:"length,omitempty"`
+	Offset int64  `json:"offset,omitempty"`
+}
 
 func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte, kargs []byte) (ImageReader, error) {
 	isoReader, err := os.Open(isoPath)
@@ -29,7 +37,7 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 		return nil, err
 	}
 
-	r, err := readerForContent(isoPath, ignitionImagePath, isoReader, ignitionReader, GetISOFileInfo)
+	r, err := readerForContent(isoPath, ignitionImagePath, isoReader, ignitionReader, ignitionBoundariesFinder)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create overwrite reader for ignition")
 	}
@@ -55,6 +63,34 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 	}
 
 	return r, nil
+}
+
+func ignitionBoundariesFinder(filePath, isoPath string) (int64, int64, error) {
+	ignitionInfoData, err := ReadFileFromISO(isoPath, ignitionInfoPath)
+	// If the igninfo.json file doesn't exist or we fail to access it, fall back to using the given ignition file
+	// This will be the case for earlier versions of RHCOS
+	if err != nil {
+		return GetISOFileInfo(filePath, isoPath)
+	}
+
+	info := &ignitionInfo{}
+	err = json.Unmarshal(ignitionInfoData, info)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	isoFileOffset, isoFileLength, err := GetISOFileInfo(info.File, isoPath)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// use the entire file offset and length if they are not specified in the info struct
+	if info.Length == 0 && info.Offset == 0 {
+		return isoFileOffset, isoFileLength, nil
+	}
+
+	// the final offset is the file offset within the ISO plus the offset within the file
+	return isoFileOffset + info.Offset, info.Length, nil
 }
 
 func readerForContent(isoPath, filePath string, base io.ReadSeeker, contentReader *bytes.Reader, boundariesFinder BoundariesFinder) (overlay.OverlayReader, error) {


### PR DESCRIPTION
## Description

Note that this is mostly a copy of #139. The differences is that there are no changes in the integration tests, and a new unit test was added to verify the use of `igninfo.json` in S390 ISOs. Below is the description originally written by @carbonin:

> If the ignition info file (/coreos/igninfo.json) is present in the ISO
> use it to determine where the ignition content should be embedded
> instead of assuming it should always go in "/images/ignition.img"
>
> If an error is encountered when reading the ignition info, fall back to
> the previous ignition path. This allows the image service to seamlessly
> support older versions without having to explicitly include logic about
> which version is being used in every call.

## How was this code tested?

Added a unit test that creates a ISO that simulates the `igninfo.json`  file of the S390 architecture.

## Assignees

/cc @filanov
/cc @ori-amizur

## Links

Resolves: https://issues.redhat.com/browse/MGMT-13692

## Checklist

- [X] Title and description added to both, commit and PR
- [X] Relevant issues have been associated
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit tests (note that code changes require unit tests)
