### PR TITLE
MGMT-16077: Add release and OS images for OCP 4.15

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -127,6 +127,30 @@ parameters:
         "cpu_architecture": "s390x",
         "url": "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/pre-release/4.13.0-rc.2/rhcos-4.13.0-rc.2-s390x-live.s390x.iso",
         "version": "413.92.202303281804-0"
+      },
+      {
+        "openshift_version": "4.15",
+        "cpu_architecture": "x86_64",
+        "url": "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.14/4.14.0/rhcos-4.14.0-x86_64-live.x86_64.iso",
+        "version": "414.92.202310170514-0"
+      },
+      {
+          "openshift_version": "4.15",
+          "cpu_architecture": "arm64",
+          "url": "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.14/4.14.0/rhcos-4.14.0-aarch64-live.aarch64.iso",
+          "version": "414.92.202310170514-0"
+      },
+      {
+          "openshift_version": "4.15",
+          "cpu_architecture": "ppc64le",
+          "url": "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.14/4.14.0/rhcos-4.14.0-ppc64le-live.ppc64le.iso",
+          "version": "414.92.202309201615-0"
+      },
+      {
+          "openshift_version": "4.15",
+          "cpu_architecture": "s390x",
+          "url": "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.14/4.14.0/rhcos-4.14.0-s390x-live.s390x.iso",
+          "version": "414.92.202309201615-0"
       }
     ]
   required: false


### PR DESCRIPTION
## Description
This clones the entries for OCP 4.14 images to OCP 4.15, as there are no officially released 4.15 images.

The actual effect of this PR is only for the integration system which uses the default value of OS_IMAGES (test-infra automation uses the configuration in assisted-service repo).

<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @adriengentil 
/cc @rccrdpccl 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
