### PR TITLE
Respect `HTTPS_CA_FILE` in the image store client

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ skipper make test
 - `DATA_DIR` - Path at which to store downloaded RHCOS images.
 - `HTTPS_CERT_FILE` - tls cert file path
 - `HTTPS_KEY_FILE` - tls key file path
+- `HTTPS_CA_FILE` - A file containing CA certificates the image service should trust when connecting to the Assisted Service and the image store
 - `HTTP_LISTEN_PORT` - When set, plain http listener is started on that port
 - `IMAGE_SERVICE_BASE_URL` - the base URL to use to query the image service
 - `LISTEN_PORT` - Image Service listen port

--- a/internal/handlers/assisted_service_client.go
+++ b/internal/handlers/assisted_service_client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -24,21 +23,12 @@ type AssistedServiceClient struct {
 
 const fileRouteFormat = "/api/assisted-install/v2/infra-envs/%s/downloads/files"
 
-func NewAssistedServiceClient(assistedServiceScheme, assistedServiceHost, caCertFile string) (*AssistedServiceClient, error) {
+func NewAssistedServiceClient(assistedServiceScheme, assistedServiceHost string, caCertPool *x509.CertPool) (*AssistedServiceClient, error) {
 	if len(assistedServiceHost) == 0 {
 		return nil, fmt.Errorf("ASSISTED_SERVICE_HOST is not set")
 	}
 	client := &http.Client{}
-	if caCertFile != "" {
-		caCert, err := os.ReadFile(caCertFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open cert file %s, %s", caCertFile, err)
-		}
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("failed to append cert %s, %s", caCertFile, err)
-		}
-
+	if caCertPool != nil {
 		t := &http.Transport{
 			TLSClientConfig: &tls.Config{
 				RootCAs:    caCertPool,


### PR DESCRIPTION
## Description
`HTTPS_CA_FILE` was only trusted by the client of the
image-service->assisted-service communication, not the client of the
image-service->image-store communication. This means that users couldn't
add certs to trust an image store that uses a custom CA

This commit makes it so that both clients will use the certs specified
in `HTTPS_CA_FILE`

## How was this code tested?

Untested, draft


## Assignees

/cc @filanov
/cc @carbonin

## Links

Partially solves MGMT-14070, further changes required in infrastructure
operator agentserviceconfig controller to accept certs that will be added to
the file that it passes to the image service at `HTTPS_CA_FILE`

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)