### PR TITLE
MGMT-16507: Enable image service to use additional ca certificates

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -281,7 +281,7 @@ var _ = BeforeSuite(func() {
 	imageDir, err = os.MkdirTemp("", "imagesTest")
 	Expect(err).To(BeNil())
 
-	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir), imageDir, imageServiceBaseURL, false, versions)
+	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir), imageDir, imageServiceBaseURL, false, versions, "")
 	Expect(err).NotTo(HaveOccurred())
 
 	err = imageStore.Populate(context.Background())


### PR DESCRIPTION
[MGMT-16507](https://issues.redhat.com//browse/MGMT-16507): Enable image service to use additional ca certificates

The infrastructure operator will make available a file at ASSISTED_SERVICE_API_TRUSTED_CA_FILE

This file will contain certificates that are to be used for certificate authority during image fetch
The purpose of this PR is to use those certificates for the fetching of images if they have been set up.

Additionally, we needed to make the  the purpose of HTTPS_CA_FILE clearer, so we added a new variable OS_IMAGE_DOWNLOAD_TRUSTED_CA_FILE
The value of OS_IMAGE_DOWNLOAD_TRUSTED_CA_FILE will default to the value held in HTTPS_CA_FILE unless overridden
The idea is to retire HTTPS_CA_FILE as it is not very clear what it's for.

OSImageDownloadTrustedCAFile is a path to a CA file that will be trusted when fetching OS Images
AssistedServiceApiTrustedCAFile is a path to a CA file that will be trusted for TLS connections to the Assisted Service API

## How was this code tested?
This code has coverage in a unit test that ensures we make a call to an HTTPS test server that will require us to use a CA.
Thas additionally been tested manually by deploying the infrastructure operator from a custom bundle.

## Assignees
/cc @carbonin 

## Links
https://github.com/openshift/assisted-service/pull/5884)


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
There is a task in the epic to handle user specific documentation
- [x] Does this change include unit tests (note that code changes require unit tests)
