### PR TITLE
MGMT-16629: Use custom query params and headers for OS image downloads

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -281,7 +281,7 @@ var _ = BeforeSuite(func() {
 	imageDir, err = os.MkdirTemp("", "imagesTest")
 	Expect(err).To(BeNil())
 
-	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir), imageDir, imageServiceBaseURL, false, versions, "")
+	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir), imageDir, imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
 	Expect(err).NotTo(HaveOccurred())
 
 	err = imageStore.Populate(context.Background())


### PR DESCRIPTION
## Description
This PR provides the ability to add custom query parameters and headers to every http request made while downloading OS images.

Two environment variables are to be provided `OS_IMAGES_HTTP_REQUEST_QUERY_PARAMS` and `OS_IMAGES_HTTP_REQUEST_HEADERS` These variables are JSON representations of `map[string]string` where the key is the parameter (or header) name and the value is the parameter (or header) value.

Once provided, these values will be used in the HTTP request headers and the HTTP query parameters of any request made during the download of OS images.


## Testing
This code includes tests to ensure that the functionality works as intended. A manual test will also be performed in podman to ensure the behavior is as expected


## Assignees
/cc @carbonin 
/cc @omertuc 

## Links
This is part of the Epic https://issues.redhat.com/browse/MGMT-15408


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
