### PR TITLE
MGMT-16952: Make sure default CA's are preserved when using custom CA

### DIFF
--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -103,7 +103,11 @@ func NewImageStore(ed isoeditor.Editor, dataDir, imageServiceBaseURL string, ins
 
 	// Add additional TLS certificates (if available) for fetching OS images
 	if osImageDownloadTrustedCAFile != "" {
-		caCertPool := x509.NewCertPool()
+		// In order to make sure we can use the "built in" CA's in addition to our custom CA, we need to make sure these are loaded in.
+		caCertPool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("failed to obtain system cert pool: %w", err)
+		}
 		additionalTLSCert, err := os.ReadFile(osImageDownloadTrustedCAFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open additional certificate file %s, %w", osImageDownloadTrustedCAFile, err)


### PR DESCRIPTION
When using a custom CA for OS image download, it was discovered that the default CA's were not being used.

This is because of how the field `RootCAs` in `TLSClientConfig` is handled in the http client;
if `RootCAs` in `TLSClientConfig` is nil then the default CA's are used, however if the value of `RootCAs` is not nil then the default CA's are overwritten.

The solution is to use x509.SystemCertPool() instead of creating a new one.

This PR ensures that our custom CA is appended to to the default CA's rather than being treated as their replacement.

## How was this code tested?
Manually tested by installation of the infrastructure operator, setting OSImageCACertRef to a valid ConfigMap containing a valid CA and using a set of OS images in the AgentServiceConfig from a mixture of sources so that some will require the custom CA and some will require "default" CA's, all should work

## Assignees
/cc @omertuc 

## Links
Work is in response to bug [MGMT-16952](https://issues.redhat.com//browse/MGMT-16952), raised as part of the QE of [MGMT-14070](https://issues.redhat.com//browse/MGMT-14070)


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
