### PR TITLE
MGMT-17006: Fix incorrect env var names used for osImageDownloadHeadersMap and osImageDownloadQueryParamsMap

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,12 +51,12 @@ var Options struct {
 
 	AssistedServiceApiTrustedCAFile string `envconfig:"ASSISTED_SERVICE_API_TRUSTED_CA_FILE"`
 
-	// OSImagesHttpRequestHeaders contains a JSON encoded representation of any
+	// OSImagesRequestHeaders contains a JSON encoded representation of any
 	// HTTP headers to be sent with every request to download an OS image.
-	OSImagesHttpRequestHeaders string `envconfig:"OS_IMAGES_HTTP_REQUEST_HEADERS" default:""`
-	// OSImagesHttpRequestQueryParams contains a JSON encoded representation of any
+	OSImagesRequestHeaders string `envconfig:"OS_IMAGES_REQUEST_HEADERS" default:""`
+	// OSImagesRequestQueryParams contains a JSON encoded representation of any
 	// query parameters to be sent with every request to download an OS image.
-	OSImagesHttpRequestQueryParams string `envconfig:"OS_IMAGES_HTTP_REQUEST_QUERY_PARAMS" default:""`
+	OSImagesRequestQueryParams string `envconfig:"OS_IMAGES_REQUEST_QUERY_PARAMS" default:""`
 }
 
 func unmarshallJSONMap(jsonMap string) (map[string]string, error) {
@@ -100,12 +100,12 @@ func main() {
 		}
 	}
 
-	osImageDownloadHeadersMap, err := unmarshallJSONMap(Options.OSImagesHttpRequestHeaders)
+	osImageDownloadHeadersMap, err := unmarshallJSONMap(Options.OSImagesRequestHeaders)
 	if err != nil {
 		log.Fatalf("Failed to unmarshal OSImageDownloadHeaders: %v\n", err)
 	}
 
-	osImageDownloadQueryParamsMap, err := unmarshallJSONMap(Options.OSImagesHttpRequestQueryParams)
+	osImageDownloadQueryParamsMap, err := unmarshallJSONMap(Options.OSImagesRequestQueryParams)
 	if err != nil {
 		log.Fatalf("Failed to unmarshal OSImageDownloadQueryParams: %v\n", err)
 	}


### PR DESCRIPTION
We recently introduced a feature that allows the passing of headers and query parameters for a request for OS images. The environment variable names we used in the image service were not consistent with the Volume bindings in the statefulset generated by the infrastructure operator.

This PR fixes that by applying the correct bindings.

This code as been tested "end to end" in a QE environment.


## Assignees
/cc @carbonin 

## Checklist

- [x] Title and description added to both, commit and PR
- x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
