### PR TITLE
MULTIARCH-2678, OCPBUGS-14478: Add a NewIgnitionImageReader() function

### DIFF
--- a/pkg/isoeditor/ignition_image.go
+++ b/pkg/isoeditor/ignition_image.go
@@ -1,0 +1,41 @@
+package isoeditor
+
+import "io"
+
+type FileData struct {
+	Filename string
+	Data     io.ReadCloser
+}
+
+// NewIgnitionImageReader returns the filename of the ignition image in the ISO,
+// along with a stream of the ignition image with ignition content embedded.
+// This can be used to overwrite the ignition image file of an ISO previously
+// unpacked by Extract() in order to embed ignition data.
+func NewIgnitionImageReader(isoPath string, ignitionContent *IgnitionContent) (FileData, error) {
+	info, iso, err := ignitionOverlay(isoPath, ignitionContent)
+	if err != nil {
+		return FileData{}, err
+	}
+	imageOffset, imageLength, err := GetISOFileInfo(info.File, isoPath)
+	if err != nil {
+		return FileData{}, err
+	}
+
+	if _, err := iso.Seek(imageOffset, io.SeekStart); err != nil {
+		iso.Close()
+		return FileData{}, err
+	}
+	data := struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: io.LimitReader(iso, imageLength),
+		Closer: iso,
+	}
+
+	ignitionImage := FileData{
+		Filename: info.File,
+		Data:     data,
+	}
+	return ignitionImage, nil
+}

--- a/pkg/isoeditor/ignition_image.go
+++ b/pkg/isoeditor/ignition_image.go
@@ -1,6 +1,10 @@
 package isoeditor
 
-import "io"
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
 
 type FileData struct {
 	Filename string
@@ -11,14 +15,15 @@ type FileData struct {
 // along with a stream of the ignition image with ignition content embedded.
 // This can be used to overwrite the ignition image file of an ISO previously
 // unpacked by Extract() in order to embed ignition data.
-func NewIgnitionImageReader(isoPath string, ignitionContent *IgnitionContent) (FileData, error) {
+func NewIgnitionImageReader(isoPath string, ignitionContent *IgnitionContent) ([]FileData, error) {
 	info, iso, err := ignitionOverlay(isoPath, ignitionContent, true)
 	if err != nil {
-		return FileData{}, err
+		return nil, err
 	}
+
 	imageOffset, imageLength, err := GetISOFileInfo(info.File, isoPath)
 	if err != nil {
-		return FileData{}, err
+		return nil, err
 	}
 
 	length := info.Offset + info.Length
@@ -29,7 +34,7 @@ func NewIgnitionImageReader(isoPath string, ignitionContent *IgnitionContent) (F
 
 	if _, err := iso.Seek(imageOffset, io.SeekStart); err != nil {
 		iso.Close()
-		return FileData{}, err
+		return nil, err
 	}
 	data := struct {
 		io.Reader
@@ -39,9 +44,25 @@ func NewIgnitionImageReader(isoPath string, ignitionContent *IgnitionContent) (F
 		Closer: iso,
 	}
 
-	ignitionImage := FileData{
+	output := []FileData{{
 		Filename: info.File,
 		Data:     data,
+	}}
+
+	// output updated igninfo.json if we have expanded the embed area
+	if length > imageLength {
+		if _, _, err := GetISOFileInfo(ignitionInfoPath, isoPath); err == nil {
+			if ignitionInfoData, err := json.Marshal(info); err == nil {
+				output = append(output, FileData{
+					Filename: ignitionInfoPath,
+					Data:     io.NopCloser(bytes.NewReader(ignitionInfoData)),
+				})
+			} else {
+				iso.Close()
+				return nil, err
+			}
+		}
 	}
-	return ignitionImage, nil
+
+	return output, nil
 }

--- a/pkg/isoeditor/ignition_image_test.go
+++ b/pkg/isoeditor/ignition_image_test.go
@@ -1,0 +1,50 @@
+package isoeditor
+
+import (
+	"io"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IgnitionContent.Archive", func() {
+	var (
+		isoFile              string
+		filesDir             string
+		ignitionContent      = []byte("someignitioncontent")
+		ignitionArchiveBytes = []byte{
+			31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 50, 48, 55, 48, 55, 48,
+			52, 128, 0, 48, 109, 97, 232, 104, 98, 128, 29, 24, 162, 113, 141, 113,
+			168, 67, 7, 78, 48, 70, 114, 126, 94, 90, 102, 186, 94, 102, 122, 30,
+			3, 3, 3, 67, 113, 126, 110, 106, 102, 122, 94, 102, 73, 102, 126, 94,
+			114, 126, 94, 73, 106, 94, 9, 3, 138, 123, 8, 1, 98, 213, 225, 116,
+			79, 72, 144, 163, 167, 143, 107, 144, 162, 162, 34, 200, 61, 128, 0, 0,
+			0, 255, 255, 191, 236, 44, 242, 12, 1, 0, 0}
+	)
+
+	BeforeEach(func() {
+		filesDir, isoFile = createTestFiles("Assisted123")
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(filesDir)).To(Succeed())
+		Expect(os.Remove(isoFile)).To(Succeed())
+	})
+
+	It("streams the ignition image", func() {
+		content := IgnitionContent{ignitionContent}
+
+		output, err := NewIgnitionImageReader(isoFile, &content)
+		Expect(err).NotTo(HaveOccurred())
+
+		imgBytes, err := io.ReadAll(output.Data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(imgBytes[:len(ignitionArchiveBytes)]).To(Equal(ignitionArchiveBytes))
+		Expect(len(imgBytes)).To(Equal(256 * 1024))
+		for i := len(ignitionArchiveBytes); i < len(imgBytes); i++ {
+			Expect(imgBytes[i]).To(Equal(byte(0)))
+		}
+		Expect(output.Filename).To(Equal("images/ignition.img"))
+	})
+})

--- a/pkg/isoeditor/ignition_image_test.go
+++ b/pkg/isoeditor/ignition_image_test.go
@@ -35,16 +35,17 @@ var _ = Describe("IgnitionContent.Archive", func() {
 	It("streams the ignition image", func() {
 		content := IgnitionContent{ignitionContent}
 
-		output, err := NewIgnitionImageReader(isoFile, &content)
+		outputs, err := NewIgnitionImageReader(isoFile, &content)
 		Expect(err).NotTo(HaveOccurred())
 
-		imgBytes, err := io.ReadAll(output.Data)
+		Expect(len(outputs)).To(Equal(1))
+		imgBytes, err := io.ReadAll(outputs[0].Data)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(imgBytes[:len(ignitionArchiveBytes)]).To(Equal(ignitionArchiveBytes))
 		Expect(len(imgBytes)).To(Equal(256 * 1024))
 		for i := len(ignitionArchiveBytes); i < len(imgBytes); i++ {
 			Expect(imgBytes[i]).To(Equal(byte(0)))
 		}
-		Expect(output.Filename).To(Equal("images/ignition.img"))
+		Expect(outputs[0].Filename).To(Equal("images/ignition.img"))
 	})
 })

--- a/pkg/isoeditor/stream.go
+++ b/pkg/isoeditor/stream.go
@@ -27,19 +27,9 @@ type ignitionInfo struct {
 }
 
 func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte, kargs []byte) (ImageReader, error) {
-	isoReader, err := os.Open(isoPath)
+	r, err := ignitionOverlay(isoPath, ignitionContent)
 	if err != nil {
 		return nil, err
-	}
-
-	ignitionReader, err := ignitionContent.Archive()
-	if err != nil {
-		return nil, err
-	}
-
-	r, err := readerForContent(isoPath, ignitionImagePath, isoReader, ignitionReader, ignitionBoundariesFinder)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create overwrite reader for ignition")
 	}
 
 	if ramdiskContent != nil {
@@ -62,6 +52,24 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 		}
 	}
 
+	return r, nil
+}
+
+func ignitionOverlay(isoPath string, ignitionContent *IgnitionContent) (overlay.OverlayReader, error) {
+	isoReader, err := os.Open(isoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	ignitionReader, err := ignitionContent.Archive()
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := readerForContent(isoPath, ignitionImagePath, isoReader, ignitionReader, ignitionBoundariesFinder)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create overwrite reader for ignition")
+	}
 	return r, nil
 }
 


### PR DESCRIPTION
Add a `NewIgnitionImageReader()` function to the `isoeditor` package that will allow the agent installer to generate the correct data for an ignition image:

- without knowing the filename (which is different on different architectures)
- even if there is other data apart from the embed area in the image (which happens on s390)
- even if the ignition data is larger than the embed area (as long as it is safe to do so)
- passing the type-safe IgnitionContent type
- reusing the same code that `NewRHCOSStreamReader()` uses to find the embed area

The function returns the filename within the ISO and a Reader for the data. This can be copied over the corresponding file in the directory unpacked by `Extract()`.