### PR TITLE
NO-ISSUE: Refactor to use isoeditor library internally for initrd

### DIFF
--- a/pkg/isoeditor/initramfs.go
+++ b/pkg/isoeditor/initramfs.go
@@ -1,11 +1,11 @@
 package isoeditor
 
 import (
+	"fmt"
 	"io"
 	"os"
 
 	"github.com/openshift/assisted-image-service/pkg/overlay"
-	"github.com/pkg/errors"
 )
 
 const initrdPathInISO = "images/pxeboot/initrd.img"
@@ -13,7 +13,7 @@ const initrdPathInISO = "images/pxeboot/initrd.img"
 func NewInitRamFSStreamReader(irfsPath string, ignitionContent *IgnitionContent) (overlay.OverlayReader, error) {
 	irfsReader, err := os.Open(irfsPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open base initrd: %w", err)
 	}
 	return newInitRamFSStreamReaderFromStream(irfsReader, ignitionContent)
 }
@@ -21,7 +21,7 @@ func NewInitRamFSStreamReader(irfsPath string, ignitionContent *IgnitionContent)
 func NewInitRamFSStreamReaderFromISO(isoPath string, ignitionContent *IgnitionContent) (overlay.OverlayReader, error) {
 	irfsReader, err := GetFileFromISO(isoPath, initrdPathInISO)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open base initrd from ISO: %w", err)
 	}
 	return newInitRamFSStreamReaderFromStream(irfsReader, ignitionContent)
 }
@@ -29,12 +29,12 @@ func NewInitRamFSStreamReaderFromISO(isoPath string, ignitionContent *IgnitionCo
 func newInitRamFSStreamReaderFromStream(irfsReader io.ReadSeekCloser, ignitionContent *IgnitionContent) (overlay.OverlayReader, error) {
 	ignitionReader, err := ignitionContent.Archive()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create ignition archive: %w", err)
 	}
 
 	r, err := overlay.NewAppendReader(irfsReader, ignitionReader)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create append reader for ignition")
+		return nil, fmt.Errorf("failed to create append reader for ignition: %w", err)
 	}
 	return r, nil
 }


### PR DESCRIPTION
Refactor the assisted image service's handler for the initramfs to make use of the identical code in the isoeditor library's `NewInitRamFSStreamReaderFromISO()` function.