### PR TITLE
OCPBUGS-14478: Pad expanded ignition embed area

### DIFF
--- a/pkg/isoeditor/stream.go
+++ b/pkg/isoeditor/stream.go
@@ -131,8 +131,11 @@ func (ibf *ignitionBoundaryFinder) findBoundaries(filePath, isoPath string) (int
 	// allow overflow if requested and if the embed area extends all the way
 	// to the end of the file
 	if ibf.allowOverflow && ((info.Offset + info.Length) >= isoFileLength) {
-		if ibf.dataSize > info.Length {
-			info.Length = ibf.dataSize
+		chunkSize := (info.Length + 3) / 4
+		if (ibf.dataSize + chunkSize) > info.Length {
+			// increase size in chunks equal to a quarter of the original size,
+			// ensuring that there is always at least one full chunk free
+			info.Length = (1 + ((ibf.dataSize + chunkSize - 1) / chunkSize)) * chunkSize
 		}
 	}
 


### PR DESCRIPTION
If the ignition embed area is expanded in the ignition image returned by `NewIgnitionImageReader()`, also add additional padding at the end of the image. This allows the ignition image to be extracted by coreos-installer and re-inserted into the image after minor changes that may make it slightly larger.

Currently the embed area is 256kB. This change ensures that the size of the image returned is a multiple of 32kB, and that there is also at least 32kB free after the provided ignition. This size is proportional to the embed area (i.e. we always leave 1/4 of the original embed area free).