### PR TITLE
AGENT-890: Add NewKargsReader() function

### DIFF
--- a/pkg/isoeditor/isolate_file.go
+++ b/pkg/isoeditor/isolate_file.go
@@ -1,0 +1,38 @@
+package isoeditor
+
+import (
+	"io"
+
+	"github.com/openshift/assisted-image-service/pkg/overlay"
+)
+
+type FileData struct {
+	Filename string
+	Data     io.ReadCloser
+}
+
+func isolateISOFile(isoPath, file string, data overlay.OverlayReader, minLength int64) (FileData, bool, error) {
+	fileOffset, fileLength, err := GetISOFileInfo(file, isoPath)
+	if err != nil {
+		return FileData{}, false, err
+	}
+
+	expanded := false
+	if minLength > fileLength {
+		fileLength = minLength
+		expanded = true
+	}
+
+	if _, err := data.Seek(fileOffset, io.SeekStart); err != nil {
+		return FileData{}, false, err
+	}
+	fileData := struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: io.LimitReader(data, fileLength),
+		Closer: data,
+	}
+
+	return FileData{Filename: file, Data: fileData}, expanded, nil
+}


### PR DESCRIPTION
Add a function analagous to the `NewIgnitionImageReader()` function, but for kargs. Given a path to an ISO and some kargs to append, it returns a list of files and the new contents that they need to be overwritten with. This will allow the agent-based installer to stop duplicating the code to append kargs in the ISO.