### PR TITLE
MULTIARCH-4515: Add support for ins-file as boot artefact.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,14 @@ Downloads the RHCOS initrd with the ignition for the specified image appended.
 
 ### `GET /boot-artifacts/{artifact}`
 
-Downloads the artifact specified from the ISO.
+Downloads the artifact specified from the ISO. Artifacts are:
+
+- `rootfs`: rootfs.img 
+- `kernel`: vmlinuz (kernel.img when arch is s390x)
+
+#### Architecture specific artifacts
+##### s390x
+- `ins-file`: generic.ins
 
 #### Query parameters
 

--- a/internal/handlers/handlers_suite_test.go
+++ b/internal/handlers/handlers_suite_test.go
@@ -31,6 +31,7 @@ func createTestISO() string {
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/pxeboot/rootfs.img"), []byte("this is rootfs"), 0600)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/pxeboot/vmlinuz"), []byte("this is kernel"), 0600)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/pxeboot/initrd.img"), []byte("this is initrd"), 0600)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(filesDir, "generic.ins"), []byte("this is generic.ins"), 0600)).To(Succeed())
 
 	cmd := exec.Command("genisoimage", "-rational-rock", "-J", "-joliet-long", "-o", isoFile, filesDir)
 	Expect(cmd.Run()).To(Succeed())

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -64,6 +64,12 @@ var DefaultVersions = []map[string]string{
 		"url":               "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/4.11.0-0.nightly-arm64-2022-04-19-171931/rhcos-4.11.0-0.nightly-arm64-2022-04-19-171931-aarch64-live.aarch64.iso",
 		"version":           "411.86.202204190940-0",
 	},
+	{
+		"openshift_version": "4.15",
+		"cpu_architecture":  "s390x",
+		"url":               "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.15/4.15.0/rhcos-live.s390x.iso",
+		"version":           "415.92.202403212258-0",
+	},
 }
 
 //go:generate mockgen -package=imagestore -destination=mock_imagestore.go . ImageStore

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -529,6 +529,12 @@ var _ = Describe("HaveVersion", func() {
 				"url":               "http://example.com/image/arm64-49.iso",
 				"version":           "49.84.202110081407-0",
 			},
+			{
+				"openshift_version": "4.15",
+				"cpu_architecture":  "s390x",
+				"url":               "http://example.com/image/s390x-415.iso",
+				"version":           "415.92.202403212258-0",
+			},
 		}
 		store ImageStore
 	)
@@ -544,6 +550,7 @@ var _ = Describe("HaveVersion", func() {
 	It("is true for versions that are present", func() {
 		Expect(store.HaveVersion("4.8", "x86_64")).To(BeTrue())
 		Expect(store.HaveVersion("4.9", "arm64")).To(BeTrue())
+		Expect(store.HaveVersion("4.15", "s390x")).To(BeTrue())
 	})
 
 	It("is false for versions that are missing", func() {
@@ -551,6 +558,7 @@ var _ = Describe("HaveVersion", func() {
 		Expect(store.HaveVersion("4.8", "arm64")).To(BeFalse())
 		Expect(store.HaveVersion("4.7", "x86_64")).To(BeFalse())
 		Expect(store.HaveVersion("4.8", "aarch64")).To(BeFalse())
+		Expect(store.HaveVersion("4.11", "s390x")).To(BeFalse())
 	})
 })
 


### PR DESCRIPTION
The ins-file will be taken from iso as rootfs, initrd and kernel.

## Description
With the support of LPAR on s390x new boot artefacts / files are needed. On LPAR (Classic and/or DPM) there are following files needed :
rootfs.img
kernel.img
initrd.img
"a ins file"
initrd.addrsize ( load address and size of initrd)
prm file (like the file used for zVM nodes)

This is the first PR to enable the gathering of the ins-file taken from the ISO (generic.ins).

This PR is for Assisted Installer, Agent-based Installer and HCP.
This new hypervisor support will be documented accordingly in the installation docs ([https://issues.redhat.com/browse/MULTIARCH-4514](https://issues.redhat.com/browse/MULTIARCH-4514))

## How was this code tested?
There are set of test cases (unit test).


## Assignees
/assign @carbonin 

## Links
[https://issues.redhat.com/browse/MULTIARCH-4515](https://issues.redhat.com/browse/MULTIARCH-45)15


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
