### PR TITLE
OCPBUGS-33240: Skip fat32 log traces when retrieving the ISO file system in the isoeditor package

### DIFF
--- a/pkg/isoeditor/isoutil.go
+++ b/pkg/isoeditor/isoutil.go
@@ -22,7 +22,7 @@ func Extract(isoPath string, workDir string) error {
 		return err
 	}
 
-	fs, err := d.GetFilesystem(0)
+	fs, err := GetISO9660FileSystem(d)
 	if err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func GetISOFileInfo(filePath, isoPath string) (int64, int64, error) {
 		return 0, 0, err
 	}
 
-	fs, err := d.GetFilesystem(0)
+	fs, err := GetISO9660FileSystem(d)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -312,7 +312,7 @@ func GetFileFromISO(isoPath, filePath string) (filesystem.File, error) {
 		return nil, err
 	}
 
-	fs, err := d.GetFilesystem(0)
+	fs, err := GetISO9660FileSystem(d)
 	if err != nil {
 		return nil, err
 	}
@@ -336,4 +336,9 @@ func ReadFileFromISO(isoPath, filePath string) ([]byte, error) {
 		return nil, err
 	}
 	return ret, nil
+}
+
+// Gets directly the ISO 9660 filesystem (equivalent to GetFileSystem(0)).
+func GetISO9660FileSystem(d *disk.Disk) (filesystem.FileSystem, error) {
+	return iso9660.Read(d.File, d.Size, 0, 0)
 }


### PR DESCRIPTION
The isoeditor package uses the [diskfs.GetFileSystem()](https://github.com/diskfs/go-diskfs/blob/7e522084e08e87ebea3c79876164b61d39e1f6f4/disk/disk.go#L203) method to access the filesystem of the ISO. Since it's a generic library supporting different types of file systems, the current implementation tries to discover the type of the requested one, checking as first the fat32 fs, loggin a debug error trace in case it isn't.

Agent-based installer uses it (indirectly) in several places when creating the agent ISO image (when the `openshift-installer agent create image` command is executed for example), thus resulting ina very noisy and somehow confusing output, i.e.:

```
level=debug msg=initDisk(): start
level=debug msg=initDisk(): regular file
level=debug msg=trying fat32
level=debug msg=fat32 failed: error reading MS-DOS Boot Sector: could not read FAT32 BIOS Parameter Block from boot sector: could not read embedded DOS 3.31 BPB: error reading embedded DOS 2.0 BPB: invalid sector size 37008 provided in DOS 2.0 BPB. Must be 512
level=debug msg=trying iso9660 with physical block size 0
level=debug msg=initDisk(): start
level=debug msg=initDisk(): regular file
level=debug msg=trying fat32
level=debug msg=fat32 failed: error reading MS-DOS Boot Sector: could not read FAT32 BIOS Parameter Block from boot sector: could not read embedded DOS 3.31 BPB: error reading embedded DOS 2.0 BPB: invalid sector size 37008 provided in DOS 2.0 BPB. Must be 512
level=debug msg=trying iso9660 with physical block size 0
level=debug msg=initDisk(): start
level=debug msg=initDisk(): regular file
level=debug msg=trying fat32
level=debug msg=fat32 failed: error reading MS-DOS Boot Sector: could not read FAT32 BIOS Parameter Block from boot sector: could not read embedded DOS 3.31 BPB: error reading embedded DOS 2.0 BPB: invalid sector size 37008 provided in DOS 2.0 BPB. Must be 512
level=debug msg=trying iso9660 with physical block size 0
level=debug msg=initDisk(): start
level=debug msg=initDisk(): regular file
level=debug msg=trying fat32
level=debug msg=fat32 failed: error reading MS-DOS Boot Sector: could not read FAT32 BIOS Parameter Block from boot sector: could not read embedded DOS 3.31 BPB: error reading embedded DOS 2.0 BPB: invalid sector size 37008 provided in DOS 2.0 BPB. Must be 512
level=debug msg=trying iso9660 with physical block size 0
```

This patch replaces the `GetFileSystem` call in the `isoeditor` package with the direct equivalent `iso9660` one (in case no partition table was specified), thus avoiding the previously shown fat32 related log traces