### PR TITLE
MULTIARCH-4515: add new endpoint to receive initrd.addrsize

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ Downloads the RHCOS initrd with the ignition for the specified image appended.
 
 - `Authorization`: this header is passed directly through to assisted service requests to handle RHSSO authentication
 
+### `GET /images/{image_id}/s390x-initrd-addrsize`
+
+Only for the s390x architecture. Downloads the initrd.addrsize (16 bytes) containing the psw of the initrd (8 bytes) and the size of the initrd (8 bytes)
+
+#### Query parameters
+
+- `version`: indicates the version of the RHCOS base image to use (must match an entry in `RHCOS_VERSIONS`)
+- `api_key`: the api token to pass through to the assisted service calls if local authentication is required
+- `image_token`: the token to pass through to the Image-Token assisted service header if image pre-signed authentication is required
+
+#### Headers
+
+- `Authorization`: this header is passed directly through to assisted service requests to handle RHSSO authentication
+
 ### `GET /boot-artifacts/{artifact}`
 
 Downloads the artifact specified from the ISO. Artifacts are:

--- a/internal/handlers/handlers_suite_test.go
+++ b/internal/handlers/handlers_suite_test.go
@@ -32,6 +32,8 @@ func createTestISO() string {
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/pxeboot/vmlinuz"), []byte("this is kernel"), 0600)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(filesDir, "images/pxeboot/initrd.img"), []byte("this is initrd"), 0600)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(filesDir, "generic.ins"), []byte("this is generic.ins"), 0600)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(filesDir, "images/initrd.addrsize"), []byte{
+		1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}, 0600)).To(Succeed())
 
 	cmd := exec.Command("genisoimage", "-rational-rock", "-J", "-joliet-long", "-o", isoFile, filesDir)
 	Expect(cmd.Run()).To(Succeed())

--- a/internal/handlers/initrd.go
+++ b/internal/handlers/initrd.go
@@ -35,40 +35,12 @@ func (h *initrdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		arch = defaultArch
 	}
 
-	if !h.ImageStore.HaveVersion(version, arch) {
-		httpErrorf(w, http.StatusBadRequest, "version for %s %s, not found", version, arch)
-		return
-	}
-
-	isoPath := h.ImageStore.PathForParams(imagestore.ImageTypeFull, version, arch)
-
-	ignition, lastModified, code, err := h.client.ignitionContent(r, imageID, "")
+	initrdReader, lastModified, code, err := initrdOverlayReader(h.ImageStore, h.client, r, arch)
 	if err != nil {
-		httpErrorf(w, code, "Error retrieving ignition content: %v", err)
-		return
-	}
-
-	initrdReader, err := isoeditor.NewInitRamFSStreamReaderFromISO(isoPath, ignition)
-	if err != nil {
-		httpErrorf(w, http.StatusInternalServerError, "Failed to get initrd: %v", err)
+		httpErrorf(w, code, err.Error())
 		return
 	}
 	defer initrdReader.Close()
-
-	ramdisk, statusCode, err := h.client.ramdiskContent(r, imageID)
-	if err != nil {
-		log.Errorf("Error retrieving ramdisk content: %v\n", err)
-		w.WriteHeader(statusCode)
-		return
-	}
-	// the content will be nil if no static networking is configured
-	if ramdisk != nil {
-		initrdReader, err = overlay.NewAppendReader(initrdReader, bytes.NewReader(ramdisk))
-		if err != nil {
-			httpErrorf(w, http.StatusInternalServerError, "Failed to create append reader for initrd: %v", err)
-			return
-		}
-	}
 
 	fileName := fmt.Sprintf("%s-initrd.img", imageID)
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileName))
@@ -78,4 +50,46 @@ func (h *initrdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		modTime = time.Now()
 	}
 	http.ServeContent(w, r, fileName, modTime, initrdReader)
+}
+
+func initrdOverlayReader(imageStore imagestore.ImageStore, client *AssistedServiceClient, r *http.Request, arch string) (overlay.OverlayReader, string, int, error) {
+	imageID := chi.URLParam(r, "image_id")
+
+	version := r.URL.Query().Get("version")
+	if version == "" {
+		return nil, "", http.StatusBadRequest, fmt.Errorf("'version' parameter required for initrd download")
+	}
+
+	// check if image is available for given version and architecture
+	if !imageStore.HaveVersion(version, arch) {
+		return nil, "", http.StatusBadRequest, fmt.Errorf("version for %s %s, not found ", version, arch)
+	}
+
+	isoPath := imageStore.PathForParams(imagestore.ImageTypeFull, version, arch)
+
+	ignition, lastModified, code, err := client.ignitionContent(r, imageID, "")
+	if err != nil {
+		return nil, "", code, fmt.Errorf("error retrieving ignition content: %v", err)
+	}
+
+	initrdReader, err := isoeditor.NewInitRamFSStreamReaderFromISO(isoPath, ignition)
+	if err != nil {
+		return nil, "", http.StatusInternalServerError, fmt.Errorf("failed to get initrd: %v", err)
+	}
+
+	ramdisk, statusCode, err := client.ramdiskContent(r, imageID)
+	if err != nil {
+		return nil, "", statusCode, fmt.Errorf("error retrieving ramdisk content: %v", err)
+	}
+
+	// the content will be nil if no static networking is configured
+	if ramdisk != nil {
+		initrdReader, err = overlay.NewAppendReader(initrdReader, bytes.NewReader(ramdisk))
+		if err != nil {
+			return nil, "", http.StatusInternalServerError, fmt.Errorf("failed to create append reader for initrd: %v", err)
+		}
+
+	}
+
+	return initrdReader, lastModified, 0, nil
 }

--- a/internal/handlers/initrd_addrsize.go
+++ b/internal/handlers/initrd_addrsize.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/openshift/assisted-image-service/pkg/imagestore"
+	"github.com/openshift/assisted-image-service/pkg/isoeditor"
+)
+
+const initrdAddrsizePathInISO = "images/initrd.addrsize"
+
+type initrdAddrSizeHandler struct {
+	ImageStore imagestore.ImageStore
+	client     *AssistedServiceClient
+}
+
+var _ http.Handler = &initrdAddrSizeHandler{}
+
+func (h *initrdAddrSizeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	imageID := chi.URLParam(r, "image_id")
+
+	version := r.URL.Query().Get("version")
+	if version == "" {
+		httpErrorf(w, http.StatusBadRequest, "'version' parameter required for initrd download")
+		return
+	}
+
+	isoPath := h.ImageStore.PathForParams(imagestore.ImageTypeFull, version, "s390x")
+
+	initrdReader, lastModified, code, err := initrdOverlayReader(h.ImageStore, h.client, r, "s390x")
+	if err != nil {
+		httpErrorf(w, code, err.Error())
+		return
+	}
+	defer initrdReader.Close()
+
+	fileName := fmt.Sprintf("%s-initrd.addrsize", imageID)
+	addrsizeReader, err := isoeditor.GetFileFromISO(isoPath, initrdAddrsizePathInISO)
+	if err != nil {
+		log.Errorf("Error retrieving initrd.addsize file: %v, isoPath; %s\n", err, isoPath)
+		httpErrorf(w, http.StatusInternalServerError, "Failed to get initrd.addrsize: %v", err)
+		return
+	}
+	defer addrsizeReader.Close()
+
+	// get the size of the initrd including the embedded ignition
+	sizeOfInitrd, err := initrdReader.Seek(0, io.SeekEnd)
+	if err != nil {
+		httpErrorf(w, http.StatusInternalServerError, "Failed to determine size of initrd: %v", err)
+		return
+	}
+
+	addrsizeBytes := new(bytes.Buffer)
+	err = binary.Write(addrsizeBytes, binary.BigEndian, sizeOfInitrd)
+	if err != nil {
+		httpErrorf(w, http.StatusInternalServerError, "Error during write buffer: %v", err)
+		return
+	}
+	initrdPSW := make([]byte, 8)
+	m, err := addrsizeReader.Read(initrdPSW)
+	if err != nil || m != 8 {
+		log.Errorf("Error reading initrd.addsize file: %v, isoPath; %s\n", err, isoPath)
+		httpErrorf(w, http.StatusInternalServerError, "Failed to read initrd.addrsize: %v", err)
+		return
+	}
+
+	modTime, err := http.ParseTime(lastModified)
+	if err != nil {
+		log.Warnf("Error parsing last modified time %s: %v", lastModified, err)
+		modTime = time.Now()
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileName))
+
+	http.ServeContent(w, r, fileName, modTime, bytes.NewReader(append(initrdPSW, addrsizeBytes.Bytes()...)))
+}

--- a/internal/handlers/initrd_addrsize_test.go
+++ b/internal/handlers/initrd_addrsize_test.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/openshift/assisted-image-service/pkg/imagestore"
+)
+
+var _ = Describe("ServeHTTP", func() {
+	var (
+		ctrl            *gomock.Controller
+		mockImageStore  *imagestore.MockImageStore
+		imageFilename   string
+		imageID         = "bf25292a-dddd-49dc-ab9c-3fb4c1f07071"
+		assistedServer  *ghttp.Server
+		ignitionContent = []byte("someignitioncontent")
+		initrdAddrsize  = []byte{
+			1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 122}
+		server       *httptest.Server
+		client       *http.Client
+		lastModified string
+		header       = http.Header{}
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockImageStore = imagestore.NewMockImageStore(ctrl)
+		imageFilename = createTestISO()
+
+		lastModified = "Fri, 22 Apr 2022 18:11:09 GMT"
+		header.Set("Last-Modified", lastModified)
+		assistedServer = ghttp.NewServer()
+		assistedServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", fmt.Sprintf(fileRouteFormat, imageID), "file_name=discovery.ign"),
+				ghttp.RespondWith(http.StatusOK, ignitionContent, header),
+			),
+		)
+		u, err := url.Parse(assistedServer.URL())
+		Expect(err).NotTo(HaveOccurred())
+
+		asc, err := NewAssistedServiceClient(u.Scheme, u.Host, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		handler := &ImageHandler{
+			s390xInitrdAddrsize: &initrdAddrSizeHandler{
+				ImageStore: mockImageStore,
+				client:     asc,
+			},
+		}
+		server = httptest.NewServer(handler.router(1))
+
+		client = server.Client()
+	})
+
+	AfterEach(func() {
+		assistedServer.Close()
+		server.Close()
+		os.Remove(imageFilename)
+	})
+
+	mockImage := func(version, arch string) {
+		mockImageStore.EXPECT().HaveVersion(version, arch).Return(true).AnyTimes()
+		mockImageStore.EXPECT().PathForParams(imagestore.ImageTypeFull, version, arch).Return(imageFilename).AnyTimes()
+	}
+
+	expectSuccessfulResponse := func(resp *http.Response, content []byte) {
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(resp.Header.Get("Content-Disposition")).To(Equal(fmt.Sprintf("attachment; filename=%s-initrd.addrsize", imageID)))
+		_, err := http.ParseTime(resp.Header.Get("Last-Modified"))
+		Expect(err).NotTo(HaveOccurred())
+		if lastModified != "" {
+			Expect(resp.Header.Get("Last-Modified")).To(Equal(lastModified))
+		}
+		respContent, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(respContent).To(Equal(content))
+	}
+
+	withNoMinimalInitrd := func() {
+		assistedServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/downloads/minimal-initrd", imageID)),
+				ghttp.RespondWith(http.StatusNoContent, []byte{}),
+			),
+		)
+	}
+
+	It("returns overlay initrd.addrsize", func() {
+		lastModified = ""
+		header.Set("Last-Modified", "somenonsense")
+		assistedServer.SetHandler(0,
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", fmt.Sprintf(fileRouteFormat, imageID), "file_name=discovery.ign"),
+				ghttp.RespondWith(http.StatusOK, ignitionContent, header),
+			),
+		)
+
+		mockImage("4.11", "s390x")
+		withNoMinimalInitrd()
+		resp, err := client.Get(fmt.Sprintf("%s/images/%s/s390x-initrd-addrsize?version=4.11", server.URL, imageID))
+		Expect(err).NotTo(HaveOccurred())
+		expectSuccessfulResponse(resp, initrdAddrsize)
+	})
+})

--- a/main.go
+++ b/main.go
@@ -183,6 +183,7 @@ func main() {
 	http.Handle("/byapikey/", imageHandler)
 	http.Handle("/byid/", imageHandler)
 	http.Handle("/bytoken/", imageHandler)
+	http.Handle("/s390x-initrd-addrsize", imageHandler)
 
 	serverInfo.ListenAndServe()
 	<-stop


### PR DESCRIPTION
Add new parameter to return initrd.addrsize file overlayed by the current size of
initrd.img and ignition.
This is only valid for s390x architecture and is necessary to support LPAR hypervisor (Classic and DPM).

This PR is the second required PR (First is https://github.com/openshift/assisted-image-service/pull/198).

This PR is for Assisted Installer, Agent-based Installer and HCP.
This new hypervisor support will be documented accordingly in the installation docs (https://issues.redhat.com/browse/MULTIARCH-4514)

Reopen #204 because of an issue in Konflux.


## How was this code tested?

Running the initrd_test suite


## Assignees
@omertuc

/cc @
/cc @

## Links
[<!--
List any applicable links to related PRs or issues
-->](https://issues.redhat.com/browse/MULTIARCH-4515)


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
