### PR TITLE
MULTIARCH-4515i: provide initrd.addrsize endpoint through isoeditor

### DIFF
--- a/pkg/isoeditor/initrd_addrsize.go
+++ b/pkg/isoeditor/initrd_addrsize.go
@@ -1,0 +1,50 @@
+package isoeditor
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/openshift/assisted-image-service/pkg/overlay"
+)
+
+const initrdAddrsizePathInISO = "images/initrd.addrsize"
+
+func NewInitrdAddrsizeReader(iafsPath string, initrdFile overlay.OverlayReader) (*bytes.Reader, error) {
+	iafsReader, err := os.Open(iafsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open base initrd.addrsize: %w", err)
+	}
+	return NewInitrdAddrsizeReaderFromStream(iafsReader, initrdFile)
+}
+
+func NewInitrdAddrsizeReaderFromISO(isoPath string, initrdFile overlay.OverlayReader) (*bytes.Reader, error) {
+	iafsReader, err := GetFileFromISO(isoPath, initrdAddrsizePathInISO)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open base initrd.addrsize from ISO: %w", err)
+	}
+	return NewInitrdAddrsizeReaderFromStream(iafsReader, initrdFile)
+}
+
+func NewInitrdAddrsizeReaderFromStream(irfsReader io.ReadSeekCloser, initrdFile overlay.OverlayReader) (*bytes.Reader, error) {
+	// get the size of the initrd including the embedded ignition
+	sizeOfInitrd, err := initrdFile.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine size of initrd: %v", err)
+	}
+
+	addrsizeBytes := new(bytes.Buffer)
+	err = binary.Write(addrsizeBytes, binary.BigEndian, sizeOfInitrd)
+	if err != nil {
+		return nil, fmt.Errorf("error during write buffer: %v", err)
+	}
+	initrdPSW := make([]byte, 8)
+	m, err := irfsReader.Read(initrdPSW)
+	if err != nil || m != 8 {
+		return nil, fmt.Errorf("failed to read initrd.addrsize: %v", err)
+	}
+
+	return bytes.NewReader(append(initrdPSW, addrsizeBytes.Bytes()...)), nil
+}

--- a/pkg/isoeditor/initrd_addrsize_test.go
+++ b/pkg/isoeditor/initrd_addrsize_test.go
@@ -1,0 +1,33 @@
+package isoeditor
+
+import (
+	"bytes"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewInitrdAddrsizeReader", func() {
+	var (
+		ignitionContent = []byte("someignitioncontent")
+		initrdAddrsize  = []byte{
+			1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 4, 0, 108}
+	)
+
+	filesDir, _ := createS390TestFiles("Assisted123", 2560000)
+	initrdPath := filepath.Join(filesDir, "images/ignition.img")
+	addrsizePath := filepath.Join(filesDir, "images/initrd.addrsize")
+	It("Get initrd.addrsize file", func() {
+		streamReader, err := NewInitRamFSStreamReader(initrdPath, &IgnitionContent{ignitionContent})
+		Expect(err).NotTo(HaveOccurred())
+
+		addrsizeFile, err := NewInitrdAddrsizeReader(addrsizePath, streamReader)
+		Expect(err).NotTo(HaveOccurred())
+		buf := new(bytes.Buffer)
+		_, err = buf.ReadFrom(addrsizeFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(initrdAddrsize).To(Equal(buf.Bytes()))
+
+	})
+})

--- a/pkg/isoeditor/isoeditor_suite_test.go
+++ b/pkg/isoeditor/isoeditor_suite_test.go
@@ -40,7 +40,6 @@ const testIgnitionInfo = `
   "file": "images/ignition.img"
 }
 `
-
 const ignitionPaddingLength = 256 * 1024 // 256KB
 
 func createTestFiles(volumeID string) (string, string) {
@@ -85,6 +84,10 @@ func createTestFiles(volumeID string) (string, string) {
 // particular it contains a '/coreos/inginfo.json' file that indicates that the ignition is
 // embedded in the '/images/cdboot.img' file instead of the usual location '/images/ignition.img'.
 func createS390TestFiles(volumeID string, minBootImageSize int64) (tmpDir string, isoFile string) {
+	initrdAddr := []byte{
+		1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 122}
+	insFileContent := []byte("someinscontent")
+
 	// Create a temporary directory:
 	tmpDir, err := os.MkdirTemp("", "isotest")
 	Expect(err).ToNot(HaveOccurred())
@@ -104,6 +107,11 @@ func createS390TestFiles(volumeID string, minBootImageSize int64) (tmpDir string
 	// Create the '/images' directoy:
 	imagesDir := filepath.Join(tmpDir, "images")
 	Expect(os.MkdirAll(imagesDir, 0755)).To(Succeed())
+
+	// Create the  '/images/initrd.addrsize', /images/ignition.img and /generic.ins files
+	Expect(os.WriteFile(filepath.Join(imagesDir, "initrd.addrsize"), initrdAddr, 0600)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(imagesDir, "ignition.img"), make([]byte, ignitionPaddingLength), 0600)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(tmpDir, "generic.ins"), insFileContent, 0600)).To(Succeed())
 
 	// Create the '/images/cdboot.img' file containing a random prefix, the ignition data, and
 	// a random suffix. The random prefix and suffix are intended to make things crash loudly


### PR DESCRIPTION
Refactor code of getting initrd.addrsize file and move the code to isoeditor to support agent-based installer.
This is required that the agend-based installer can use the isoeditor to gather the initrd.addrsize file

## Description
Move the calculation code from initrd_addrsize handler to isoeditor (smiliar to initrd)


## How was this code tested?
Running initrd_addsize test suit.


## Assignees
@carbonin 

/cc @
/cc @

## Links
See PRs:
https://github.com/openshift/assisted-image-service/pull/207
https://github.com/openshift/assisted-image-service/pull/199


## Checklist

- [X] Title and description added to both, commit and PR
- [X] Relevant issues have been associated
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit tests (note that code changes require unit tests)
