### PR TITLE
NO-ISSUE: Download rpm packages in a different stage at the build of Dockerfile-build

### DIFF
--- a/Dockerfile.image-service-build
+++ b/Dockerfile.image-service-build
@@ -1,6 +1,19 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.21
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
+
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 
-COPY hack/setup_env.sh ./
-RUN ./setup_env.sh
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+RUN go install golang.org/x/tools/cmd/goimports@v0.22.0
+RUN go install github.com/golang/mock/mockgen@v1.6.0
+
+FROM quay.io/centos/centos:stream9
+
+RUN dnf install -y podman genisoimage make && dnf clean all
+
+ENV GOROOT=/usr/lib/golang
+ENV GOPATH=/opt/app-root/src/go
+ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+COPY --from=golang $GOPATH $GOPATH
+COPY --from=golang $GOROOT $GOROOT

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-yum install -y install podman genisoimage && yum clean all
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.0
-GOFLAGS='' go install golang.org/x/tools/cmd/goimports@v0.1.5
-GOFLAGS='' go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
Download rpm packages in a different stage at the build of Dockerfile-build as golang image is based on centos 7 which cannot reach its repositories as it is EOL