### PR TITLE
NO-ISSUE: Ensure data dir is writable by UID/GID

### DIFF
--- a/Dockerfile.image-service
+++ b/Dockerfile.image-service
@@ -37,12 +37,14 @@ LABEL maintainer "Red Hat"
 COPY --from=licenses /tmp/licenses /licenses
 
 ARG DATA_DIR=/data
-RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR
+ARG UID=1001
+ARG GID=1001
+RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR && chown $UID:$GID /data
 VOLUME $DATA_DIR
 ENV DATA_DIR=$DATA_DIR
 
 COPY --from=builder /assisted-image-service /assisted-image-service
 
-USER 1001:1001
+USER $UID:$GID
 
 CMD ["/assisted-image-service"]


### PR DESCRIPTION
Currently, the image service fails to start using podman with a
permission error:

```
{“file”:“/go/src/github.com/openshift/origin/main.go:132",“func”:“main.main.func1",“level”:“fatal”,“msg”:“Failed to populate image store: failed to download https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.14/4.14.15/rhcos-4.14.15-x86_64-live.x86_64.iso: unable to create a temp file for /data/rhcos-full-iso-4.14-414.92.202402130420-0-x86_64.iso: open /data/.rhcos-full-iso-4.14-414.92.202402130420-0-x86_64.iso271460763: permission denied\n”,“time”:“2024-07-02T15:46:45Z”}
```

This change ensures that `/data` directory is writable for the UID/GID
that will be used to execute the image service executable.
