### PR TITLE
[release-ocm-2.9] NO-ISSUE: Download rpm packages in a different stage at the build of Dockerfile-build

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-9-release-golang-1.19-openshift-4.14


### PR DESCRIPTION
Download rpm packages in a different stage at the build of Dockerfile-build as golang image is based on centos 7 which cannot reach its repositories as it is EOL