### PR TITLE
[release-ocm-2.9] NO-ISSUE: Align build dockerfile with centos9

### DIFF
--- a/Dockerfile.image-service-build
+++ b/Dockerfile.image-service-build
@@ -1,6 +1,19 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
-ENV GO111MODULE=on
-ENV GOFLAGS=""
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19 AS golang
 
-COPY hack/setup_env.sh ./
-RUN ./setup_env.sh
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.0
+RUN go install golang.org/x/tools/cmd/goimports@v0.1.5
+RUN go install github.com/golang/mock/mockgen@v1.6.0
+
+FROM quay.io/centos/centos:stream9
+
+RUN dnf install -y podman genisoimage make util-linux gcc openssl-devel && dnf clean all
+
+ENV GOROOT=/usr/lib/golang
+ENV GOPATH=/go
+ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+COPY --from=golang /opt/app-root/src/go $GOPATH
+COPY --from=golang $GOROOT $GOROOT
+
+ENV CGO_ENABLED=1
+ENV GOFLAGS=""

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@ COVER_PROFILE := $(or ${COVER_PROFILE},$(REPORTS)/unit_coverage.out)
 build:
 	podman build -f Dockerfile.image-service . -t $(IMAGE)
 
-build-openshift-ci-test-bin:
-	./hack/setup_env.sh
-
 lint:
 	golangci-lint run -v
 

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-yum install -y install podman genisoimage && yum clean all
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.0
-GOFLAGS='' go install golang.org/x/tools/cmd/goimports@v0.1.5
-GOFLAGS='' go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

Align build dockerfile to use go-toolset for go binary and centos9 for dependencies

setup_env.sh had been removed from prow release so I think it could be removed

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

running various skipper command

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @danmanor 
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
