### PR TITLE
NO-ISSUE: Add renovate config to limit number of PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+    "schedule": ["on Saturday"],
+    "groupName": "Konflux build pipeline",
+    "includePaths": [".tekton/*"],
+    "commitMessagePrefix": "NO-ISSUE: ",
+    "prBodyNotes": [
+        "/lgtm",
+        "/approve"
+    ]
+}
+


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

Since Konflux added renovates a lot of PR are created

Adding this configuration will

* gather PRs created simultaneously into a single one
* PRs will be created once a week (on Saturday)
* It seems that PR will still requires some manual /lgtm (still require some investigation)

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
N.A

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @danmanor 
/cc @adriengentil 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
