### PR TITLE
[release-ocm-2.9] MGMT-18332: Download rpm packages in a different stage at the build of Dockerfile-build

### DIFF
--- a/Dockerfile.image-service-build
+++ b/Dockerfile.image-service-build
@@ -1,6 +1,27 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
-ENV GO111MODULE=on
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18 AS golang
+
 ENV GOFLAGS=""
 
-COPY hack/setup_env.sh ./
-RUN ./setup_env.sh
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.0 && \
+        go install golang.org/x/tools/cmd/goimports@v0.1.5 && \
+        go install github.com/golang/mock/mockgen@v1.6.0
+
+FROM quay.io/centos/centos:stream9
+
+RUN dnf install -y \
+        podman \ 
+        genisoimage \ 
+        make \
+        git \ 
+        gcc \
+        openssl-devel && \
+        dnf clean all
+
+ENV GOPATH=/opt/app-root/src/go
+ENV GOROOT=/usr/lib/golang
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+COPY --from=golang $GOPATH $GOPATH
+COPY --from=golang $GOROOT $GOROOT
+
+RUN chmod 775 -R $GOPATH && chmod 775 -R $GOROOT

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@ COVER_PROFILE := $(or ${COVER_PROFILE},$(REPORTS)/unit_coverage.out)
 build:
 	podman build -f Dockerfile.image-service . -t $(IMAGE)
 
-build-openshift-ci-test-bin:
-	./hack/setup_env.sh
-
 lint:
 	golangci-lint run -v
 

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-yum install -y install podman genisoimage && yum clean all
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.0
-GOFLAGS='' go install golang.org/x/tools/cmd/goimports@v0.1.5
-GOFLAGS='' go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
Download rpm packages in a different stage at the build of Dockerfile-build as golang image is based on centos 7 which cannot reach its repositories as it is EOL