### PR TITLE
NO-ISSUE: Allow goup root to write into data dir

### DIFF
--- a/Dockerfile.image-service
+++ b/Dockerfile.image-service
@@ -36,9 +36,13 @@ LABEL maintainer "Red Hat"
 
 COPY --from=licenses /tmp/licenses /licenses
 
+
+# Ensure UID can write in data dir (e.g.: when using podman, docker, ...)
+# Ensure root group can write in data dir when deployed on OCP
+# https://docs.openshift.com/container-platform/4.16/openshift_images/create-images.html#use-uid_create-images
 ARG DATA_DIR=/data
 ARG UID=1001
-ARG GID=1001
+ARG GID=0
 RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR && chown $UID:$GID /data
 VOLUME $DATA_DIR
 ENV DATA_DIR=$DATA_DIR


### PR DESCRIPTION
When deployed on OCP, we need to allow the group "root" to write in
data dir because the UID will be randomly selected.

https://docs.openshift.com/container-platform/4.16/openshift_images/create-images.html#use-uid_create-images
