### PR TITLE
NO-ISSUE: Revert to golangci-lint 1.53.1

### DIFF
--- a/Dockerfile.image-service-build
+++ b/Dockerfile.image-service-build
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.1
 RUN go install golang.org/x/tools/cmd/goimports@v0.22.0
 RUN go install github.com/golang/mock/mockgen@v1.6.0
 


### PR DESCRIPTION
PR https://github.com/openshift/release/pull/53985 naturally bumped
golangci-lint, and now the lint job fails.

This PR revert the use of the old version of golangci-lint in order to
make the lint job pass.

x-ref: https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-assisted-image-service-main-edge-lint