### PR TITLE
MGMT-18578 - Add nmstatectl binary to initrd in minimal ISO for OCP 4.13-4.17 (x86_64 architecture)

### DIFF
--- a/Dockerfile.image-service
+++ b/Dockerfile.image-service
@@ -43,6 +43,8 @@ RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR && chown $UID:$GID /data
 VOLUME $DATA_DIR
 ENV DATA_DIR=$DATA_DIR
 
+RUN dnf install -y nmstate && dnf clean all
+
 USER $UID:$GID
 
 COPY --from=golang /tmp/licenses /licenses

--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -281,7 +281,10 @@ var _ = BeforeSuite(func() {
 	imageDir, err = os.MkdirTemp("", "imagesTest")
 	Expect(err).To(BeNil())
 
-	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir), imageDir, imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
+	nmstatectl, err := os.CreateTemp(os.TempDir(), "nmstatectl")
+	Expect(err).ToNot(HaveOccurred())
+
+	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir, nmstatectl.Name()), imageDir, imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
 	Expect(err).NotTo(HaveOccurred())
 
 	err = imageStore.Populate(context.Background())

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func main() {
 	}
 
 	is, err := imagestore.NewImageStore(
-		isoeditor.NewEditor(Options.DataDir),
+		isoeditor.NewEditor(Options.DataDir, isoeditor.NmstatectlPath),
 		Options.DataDir,
 		Options.ImageServiceBaseURL,
 		Options.InsecureSkipVerify,

--- a/pkg/isoeditor/ignition.go
+++ b/pkg/isoeditor/ignition.go
@@ -2,10 +2,6 @@ package isoeditor
 
 import (
 	"bytes"
-	"compress/gzip"
-
-	"github.com/cavaliercoder/go-cpio"
-	"github.com/pkg/errors"
 )
 
 type IgnitionContent struct {
@@ -13,36 +9,9 @@ type IgnitionContent struct {
 }
 
 func (ic *IgnitionContent) Archive() (*bytes.Reader, error) {
-	// Run gzip compression
-	compressedBuffer := new(bytes.Buffer)
-	gzipWriter := gzip.NewWriter(compressedBuffer)
-	// Create CPIO archive
-	cpioWriter := cpio.NewWriter(gzipWriter)
-
-	if err := cpioWriter.WriteHeader(&cpio.Header{
-		Name: "config.ign",
-		Mode: 0o100_644,
-		Size: int64(len(ic.Config)),
-	}); err != nil {
-		return nil, errors.Wrap(err, "Failed to write CPIO header")
+	compressedCpio, err := generateCompressedCPIO(ic.Config, "config.ign", 0o100_644)
+	if err != nil {
+		return nil, err
 	}
-	if _, err := cpioWriter.Write(ic.Config); err != nil {
-		return nil, errors.Wrap(err, "Failed to write CPIO archive")
-	}
-
-	if err := cpioWriter.Close(); err != nil {
-		return nil, errors.Wrap(err, "Failed to close CPIO archive")
-	}
-	if err := gzipWriter.Close(); err != nil {
-		return nil, errors.Wrap(err, "Failed to gzip ignition config")
-	}
-
-	padSize := (4 - (compressedBuffer.Len() % 4)) % 4
-	for i := 0; i < padSize; i++ {
-		if err := compressedBuffer.WriteByte(0); err != nil {
-			return nil, err
-		}
-	}
-
-	return bytes.NewReader(compressedBuffer.Bytes()), nil
+	return bytes.NewReader(compressedCpio), nil
 }


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->
As part of integrating the nmstate service into our flow, it's necessary to include the `nmstatectl` binary in the initrd for minimal ISO cases. This ensures that the pre-network-manager-config service can run the nmstate service early during the boot process, allowing the nmstate YAML to be applied as keyfiles.
Note: In a later phase, I will fetch the binary from the rootfs. This PR is just the initial implementation. See - [MGMT-18577](https://issues.redhat.com/browse/MGMT-18577)


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
To verify this, I used test-infra's Minikube, generated and downloaded the minimal ISO, then interrupted the boot process to confirm that the `nmstate.img` was successfully added to the initrd.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @danielerez 
/cc @carbonin 
/cc @jhernand 
/cc @AlonaKaplan 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [X] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit tests (note that code changes require unit tests)
