### PR TITLE
MGMT-19128: Migrate assisted-image-service to Konflux

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -2,14 +2,17 @@
 
 set -exu
 
-TAG=$(git rev-parse --short=7 HEAD)
+TAG=$(git rev-parse HEAD)
+SHORT_TAG=$(git rev-parse --short=7 HEAD)
 REPO="quay.io/app-sre/assisted-image-service"
 IMAGE="${REPO}:${TAG}"
 
-docker build -f Dockerfile.image-service . -t ${IMAGE} --no-cache
+docker build -f Dockerfile.image-service . -t "${IMAGE}" --no-cache
 
 docker login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
 
+docker tag "${IMAGE}" "${REPO}:${SHORT_TAG}"
 docker tag "${IMAGE}" "${REPO}:latest"
 docker push "${IMAGE}"
+docker push "${REPO}:${SHORT_TAG}"
 docker push "${REPO}:latest"


### PR DESCRIPTION
We want to change app-interface to deploy the images that Konflux builds and by default Konflux uses the full commit sha as the tag.
In order to avoid issues with telling app-interface to use the full commit sha, I am updating build_deploy.sh to push both the full sha and the short sha as image tags.

Part of [MGMT-19128](https://issues.redhat.com//browse/MGMT-19128)