### PR TITLE
MGMT-18693: Change efiLoadSectors block size

### DIFF
--- a/pkg/isoeditor/isoutil.go
+++ b/pkg/isoeditor/isoutil.go
@@ -205,12 +205,14 @@ func Create(outPath string, workDir string, volumeLabel string) error {
 
 // Returns the number of sectors to load for efi boot
 // Load Sectors * 2048 should be the size of efiboot.img rounded up to a multiple of 2048
+// For UEFI boot, the sector size is 512
+// To support iso9660 (2048) and UEFI (512), sectors must be in blocks of 512, but must also be a multiple of 2048
 func efiLoadSectors(workDir string) (uint16, error) {
 	efiStat, err := os.Stat(filepath.Join(workDir, "images/efiboot.img"))
 	if err != nil {
 		return 0, err
 	}
-	return uint16(math.Ceil(float64(efiStat.Size()) / 2048)), nil
+	return uint16(math.Ceil(float64(efiStat.Size())/2048) * 4), nil
 }
 
 func cdbootLoadSectors(workDir string) (result uint16, err error) {

--- a/pkg/isoeditor/isoutil_test.go
+++ b/pkg/isoeditor/isoutil_test.go
@@ -361,7 +361,7 @@ var _ = Context("with test files", func() {
 		It("returns the correct value", func() {
 			sectors, err := efiLoadSectors(filesDir)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(sectors).To(Equal(uint16(3997)))
+			Expect(sectors).To(Equal(uint16(15988)))
 		})
 	})
 })


### PR DESCRIPTION
## Description
Analyzing the problem we had reported about the creation of hybrid images (boot from CD and USB sticks) in the appliance project I have found a problem with the calculation of the EFI image sectors in the ElTorito information table.

Until now, to calculate the number of sectors used we were using a block of 2048 bits (sector size for an iso9660), but however it seems that the sector used for the calculation is actually 512 bytes.

This difference in sectors causes the `isohybrid`, when preparing the image, to create an EFI partition that is too small and cut the bootloader:
```shell
$ ls -lh /mnt/images/efiboot.img                                                        
-rw-r--r--. 1 root root 4.9M Oct 22 10:36 /mnt/images/efiboot.img

$ fdisk -l appliance.iso
Disk appliance.iso: 37.8 GiB, 40584085504 bytes, 79265792 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x2941a479

Device         Boot    Start      End  Sectors  Size Id Type
appliance.iso1 *           0 79265791 79265792 37.8G  0 Empty
appliance.iso2      76881568 76884057     2490  1.2M ef EFI (FAT-12/16/32)
```

The expected result is four times the number of sectors:
```shell
$ fdisk -l appliance.iso
Disk appliance.iso: 37.8 GiB, 40584085504 bytes, 79265792 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x029b0490

Device         Boot    Start      End  Sectors  Size Id Type
appliance.iso1 *           0 79265791 79265792 37.8G  0 Empty
appliance.iso2      76881572 76891531     9960  4.9M ef EFI (FAT-12/16/32)
```

For comparison, this is the information table for the RHCOS Live ISO, which is the one we used as the base image to create ours. Here you can see how it is using a sector size of 512 bytes (`Ldsiz`).
```shell
$ xorriso -indev rhcos-416.94.202406251923-0-live.x86_64.iso -report_el_torito plain
xorriso 1.4.8 : RockRidge filesystem manipulator, libburnia project.

xorriso : NOTE : Loading ISO image tree from LBA 0
xorriso : UPDATE : 25 nodes read in 1 seconds
xorriso : NOTE : Detected El-Torito boot information which currently is set to be discarded
Drive current: -indev 'rhcos-416.94.202406251923-0-live.x86_64.iso'
Media current: stdio file, overwriteable
Media status : is written , is appendable
Boot record  : El Torito , MBR isohybrid cyl-align-off GPT
Media summary: 1 session, 595808 data blocks, 1164m data,  488g free
Volume id    : 'rhcos-416.94.202406251923-0'
El Torito catalog  : 44  1
El Torito cat path : /isolinux/boot.cat
El Torito images   :   N  Pltf  B   Emul  Ld_seg  Hdpt  Ldsiz         LBA
El Torito boot img :   1  BIOS  y   none  0x0000  0x00      4        2535
El Torito boot img :   2  UEFI  y   none  0x0000  0x00   9960          45
El Torito img path :   1  /isolinux/isolinux.bin
El Torito img opts :   1  boot-info-table isohybrid-suitable
El Torito img path :   2  /images/efiboot.img
```

## How was this code tested?
The code has been tested manually by booting ISOs generated on VMs (CD & USB) and physical hardware in UEFI mode with a USB stick.


## Assignees
/cc @carbonin 
/assign @carbonin 

## Links
[xorriso manual page](https://www.gnu.org/software/xorriso/man_1_xorrisofs.html) (Check description of `boot-load-size`)


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
