### PR TITLE
MGMT-19271: Using CPIO as an alternative approach to extract the rootfs instead of p7zip

### DIFF
--- a/Dockerfile.image-service
+++ b/Dockerfile.image-service
@@ -43,8 +43,7 @@ RUN mkdir $DATA_DIR && chmod 775 $DATA_DIR && chown $UID:$GID /data
 VOLUME $DATA_DIR
 ENV DATA_DIR=$DATA_DIR
 
-RUN dnf install -y epel-release && \
-    dnf install -y p7zip-plugins squashfs-tools && dnf clean all
+RUN dnf install -y cpio squashfs-tools && dnf clean all
 
 USER $UID:$GID
 

--- a/Dockerfile.image-service-build
+++ b/Dockerfile.image-service-build
@@ -8,14 +8,13 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
 
 FROM quay.io/centos/centos:stream9
 
-RUN dnf install -y epel-release && \
-    dnf install -y podman \
+RUN dnf install -y podman \
     genisoimage \
     make \
     openssl-devel \
     gcc \
     git \
-    p7zip-plugins \
+    cpio \
     squashfs-tools \
     && dnf clean all
 

--- a/pkg/isoeditor/nmstate_handler.go
+++ b/pkg/isoeditor/nmstate_handler.go
@@ -80,9 +80,9 @@ func (n *nmstateHandler) CreateNmstateRamDisk(rootfsPath, ramDiskPath string) er
 
 // TODO: Update the code to utilize go-diskfs's squashfs instead of unsquashfs once go-diskfs supports the zstd compression format used by CoreOS - MGMT-19227
 func (n *nmstateHandler) extractNmstatectl(rootfsPath, nmstateDir string) (string, error) {
-	_, err := n.executer.Execute(fmt.Sprintf("7z x %s", rootfsPath), nmstateDir)
+	_, err := n.executer.Execute(fmt.Sprintf("cat %s | cpio -i", rootfsPath), nmstateDir)
 	if err != nil {
-		log.Errorf("failed to 7z x rootfs.img: %v", err.Error())
+		log.Errorf("failed to extract rootfs.img using cpio command: %v", err.Error())
 		return "", err
 	}
 	// limiting files is needed on el<=9 due to https://github.com/plougher/squashfs-tools/issues/125


### PR DESCRIPTION
Following this thread - https://redhat-internal.slack.com/archives/C02AX10EQJW/p1731502735110969 , since we can't use the epel pkg, specifically the p7zip pkg, we are now using CPIO to extract the root filesystem.

## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @danielerez 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [X] Title and description added to both, commit and PR
- [X] Relevant issues have been associated
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
