### PR TITLE
MGMT-19507: Stop using multi-arch builds in konflux

### DIFF
--- a/.tekton/assisted-image-service-mce-downstream-2-13-pull-request.yaml
+++ b/.tekton/assisted-image-service-mce-downstream-2-13-pull-request.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.image-service-mce
   - name: path-context

--- a/.tekton/assisted-image-service-mce-downstream-2-13-push.yaml
+++ b/.tekton/assisted-image-service-mce-downstream-2-13-push.yaml
@@ -26,9 +26,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.image-service-mce
   - name: path-context

--- a/.tekton/assisted-image-service-mce-downstream-main-pull-request.yaml
+++ b/.tekton/assisted-image-service-mce-downstream-main-pull-request.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.image-service-mce
   - name: path-context

--- a/.tekton/assisted-image-service-mce-downstream-main-push.yaml
+++ b/.tekton/assisted-image-service-mce-downstream-main-push.yaml
@@ -26,9 +26,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.image-service-mce
   - name: path-context


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

A lot of time our pipelines as well as other teams' pipelines are stuck because they are unable to provision hosts with different architectures to build the images.
Because we currently don't use the multi-arch images we build with konflux, we will stop building multi-arch for now and readd those architectures when we need them.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @pastequo 
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->

Part-of [MGMT-19507](https://issues.redhat.com//browse/MGMT-19507)

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
