### PR TITLE
NO-ISSUE: Update buildah image to fix a bug with SBOM

### DIFF
--- a/.tekton/assisted-image-service-mce-downstream-2-13-pull-request.yaml
+++ b/.tekton/assisted-image-service-mce-downstream-2-13-pull-request.yaml
@@ -253,7 +253,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/assisted-image-service-mce-downstream-2-13-push.yaml
+++ b/.tekton/assisted-image-service-mce-downstream-2-13-push.yaml
@@ -250,7 +250,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/assisted-image-service-mce-downstream-main-pull-request.yaml
+++ b/.tekton/assisted-image-service-mce-downstream-main-pull-request.yaml
@@ -253,7 +253,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/assisted-image-service-mce-downstream-main-push.yaml
+++ b/.tekton/assisted-image-service-mce-downstream-main-push.yaml
@@ -250,7 +250,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/assisted-image-service-saas-main-pull-request.yaml
+++ b/.tekton/assisted-image-service-saas-main-pull-request.yaml
@@ -237,7 +237,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.3@sha256:512c864f39ba81a730d8294247d7e1f420375c7d316f007639b13ada09f5d1c4
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.3@sha256:53efe25914fda4d79881889bce52240d99c388eb1e177abec19b8e94e1a99455
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/assisted-image-service-saas-main-push.yaml
+++ b/.tekton/assisted-image-service-saas-main-push.yaml
@@ -234,7 +234,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.3@sha256:512c864f39ba81a730d8294247d7e1f420375c7d316f007639b13ada09f5d1c4
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.3@sha256:53efe25914fda4d79881889bce52240d99c388eb1e177abec19b8e94e1a99455
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

The current buildah images in the tekton pipelines accidentally create the SBOM with CycloneDX 1.6 which causes a violation in the ECP check.
These new images set the CycloneDX to 1.5 as the ECP check expects.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @pastequo
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
