### PR TITLE
MGMT-19819: Add the commit reference from which the image is built to the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 build
 data
 **/Dockerfile.*

--- a/Dockerfile.image-service
+++ b/Dockerfile.image-service
@@ -15,6 +15,9 @@ RUN CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o /assisted-image-service 
 RUN go install github.com/google/go-licenses@v1.6.0
 RUN ${HOME}/go/bin/go-licenses save --save_path /tmp/licenses ./...
 
+# Extract the commit reference from which the image is built
+RUN cd /app && git rev-parse --short HEAD > /commit-reference.txt
+
 ## Runtime
 FROM quay.io/centos/centos:stream9
 
@@ -44,6 +47,9 @@ VOLUME $DATA_DIR
 ENV DATA_DIR=$DATA_DIR
 
 RUN dnf install -y cpio squashfs-tools && dnf clean all
+
+# Copy the commit reference from the builder
+COPY --from=golang /commit-reference.txt /commit-reference.txt
 
 USER $UID:$GID
 


### PR DESCRIPTION
## Description
Currently, in most of assisted installer components CI images we don't have a way to tell from which commit reference the image was built. Since We use an image stream for each component, and we import these streams from one CI component configuration to another, we might end up with images to are not up-to-date. In this case, we would like to have the ability to check if this is actually the case.

## How was this code tested?
CI tests image building, also built locally.
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @adriengentil 
/cc @pastequo 
/cc @rccrdpccl  

## Links
No Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
