### PR TITLE
MGMT-19211: set reasonable resource limits for the pods

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -170,7 +170,7 @@ parameters:
 - name: CPU_REQUEST
   value: "100m"
 - name: CPU_LIMIT
-  value: "200m"
+  value: "1"
 - name: MEMORY_REQUEST
   value: "400Mi"
 - name: MEMORY_LIMIT


### PR DESCRIPTION
## Description
[MGMT-19211](https://issues.redhat.com//browse/MGMT-19211): set reasonable resource limits for the pods
Setting the CPU limit to 1 is expected to prevent the pods from throttling and so improve the performance significantly during the startup phase.

## How was this code tested?
Several resource limit values were performance tested with assisted-test-infra cluster and compared to current settings.
Multiple tests were executed using different resource limit combinations, and measured the time needed both for downloading the images and creating the minimal ISOs. All cases used the full set of 30 images just like in the staging env.

**Findings**

- Download time is not affected by memory limit
- Download time starts to increase with CPU limit values under 1. At current limit (200m) the download time gets twice the no limit case, meaning ~5 minutes extra time in the test setup.
- ISO creation time starts slowly and evenly increasing already below 35Gi memory limit, but even the highest value at current limit (800Mi) means only ~40 seconds extra time compared to no memory limit.
- ISO creation time is significantly affected by CPU limit. It started to increase with less than 2 CPUs, and really struggles around 500m and below. The current limit of 200m lead to ~5 minutes extra time, almost 5 times increase compared to no limit case.

**Summary of most relevant limit value combinations**
```
  CPU  Memory  Total
limit   limit   time

 200m   800Mi  18:38 -> current settings, terrible performance
    1   800Mi  07:16 -> lowest possible limits before significant performance drop
    1     5Gi  06:58 -> reasonably low limits, fine performance
    2    35Gi  06:18 -> lowest values with no impact yet
  ---     ---  06:17 -> unlimited resources, reference performance
```

## Assignees
/cc @rccrdpccl 
/cc @adriengentil 

## Checklist
- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
