### PR TITLE
[release-ocm-2.10] MGMT-19819: Add the commit reference from which the image is built to the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 build
 data
 **/Dockerfile.*

--- a/Dockerfile.image-service
+++ b/Dockerfile.image-service
@@ -8,6 +8,10 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o /assisted-image-service main.go
 
+# Extract the commit reference from which the image is built
+RUN git config --global --add safe.directory '*' && \
+    git rev-parse --short HEAD > /commit-reference.txt
+
 FROM quay.io/centos/centos:stream9
 
 ARG DATA_DIR=/data
@@ -16,4 +20,8 @@ VOLUME $DATA_DIR
 ENV DATA_DIR=$DATA_DIR
 
 COPY --from=golang /assisted-image-service /assisted-image-service
+
+# Copy the commit reference from the builder
+COPY --from=golang /commit-reference.txt /commit-reference.txt
+
 CMD ["/assisted-image-service"]


### PR DESCRIPTION
Currently, in most of assisted installer components CI images we don't have a way to tell from which commit reference the image was built. Since We use an image stream for each component, and we import these streams from one CI component configuration to another, we might end up with images to are not up-to-date. In this case, we would like to have the ability to check if this is actually the case.