### PR TITLE
MGMT-19211: use static values for volume mount paths

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -261,9 +261,9 @@ objects:
             successThreshold: ${{READINESS_PROBE_SUCCESS_THRESHOLD}}
           volumeMounts:
           - name: assisted-image-service
-            mountPath: "${DATA_DIR}"
+            mountPath: /data
           - name: data-temp-volume
-            mountPath: "${DATA_TEMP_DIR}"
+            mountPath: /data_temp
         volumes:
         - name: data-temp-volume
           emptyDir: {}


### PR DESCRIPTION
[MGMT-19211](https://issues.redhat.com//browse/MGMT-19211): mount path values were not populated from parameters, which blocked the pods from starting, so using static values instead

/cc @rccrdpccl 
