### PR TITLE
OCPBUGS-51209:  Fixing artifact name issue for vmlinuz in  latest rhelVersions

### DIFF
--- a/internal/handlers/boot_artifacts.go
+++ b/internal/handlers/boot_artifacts.go
@@ -31,6 +31,7 @@ func parseArtifact(path, arch, version string) (string, error) {
 	}
 
 	var artifact string
+	// Fetching rhelVersion from IsoFileName
 	rhelVersion, err := strconv.Atoi(strings.Split(strings.Split(IsoFileName, version+"-")[1], ".")[1])
 	if err != nil {
 		fmt.Println("Error in fetching RHCOS Version from ISO file")

--- a/internal/handlers/boot_artifacts.go
+++ b/internal/handlers/boot_artifacts.go
@@ -29,9 +29,19 @@ func parseArtifact(path, arch, version, isoFileName string) (string, error) {
 	}
 
 	var artifact string
+	var rhelVersion int
+	var err error
 
-	// Fetching rhelVersion from IsoFileName
-	rhelVersion, err := strconv.Atoi(strings.Split(strings.Split(isoFileName, version+"-")[1], ".")[1])
+	// Fetching rhcosVersion from isoFileName
+
+	rhcosVersionSplit := strings.Split(isoFileName, version+"-")
+	rhcosVersion := rhcosVersionSplit[len(rhcosVersionSplit)-1]
+
+	// Fetching rhelVersion from rhcosVersiom
+	if len(strings.Split(rhcosVersion, ".")) > 1 {
+		rhelVersion, err = strconv.Atoi(strings.Split(rhcosVersion, ".")[1])
+	}
+
 	if err != nil {
 		fmt.Println("Error in fetching RHCOS Version from ISO file")
 		return "", err

--- a/internal/handlers/boot_artifacts_test.go
+++ b/internal/handlers/boot_artifacts_test.go
@@ -150,8 +150,8 @@ var _ = Describe("ServeHTTP", func() {
 })
 
 var _ = DescribeTable("parseArtifact",
-	func(path, arch, version, isoFileName, artifact string, success bool) {
-		a, err := parseArtifact(path, arch, version, isoFileName)
+	func(path, arch, artifact string, success bool) {
+		a, err := parseArtifact(path, arch)
 		if success {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(a).To(Equal(artifact))
@@ -159,11 +159,20 @@ var _ = DescribeTable("parseArtifact",
 			Expect(err).To(HaveOccurred())
 		}
 	},
-	Entry("returns rootfs correctly", "/boot-artifacts/rootfs", "x86_64", "4.18.1", "/data/rhcos-full-iso-4.18.1-418.94.202502100215-0-x86_64.iso", "rootfs.img", true),
-	Entry("returns kernel correctly", "/boot-artifacts/kernel", "x86_64", "4.19.0", "/data/rhcos-full-iso-4.19.0-419.96.202502102012-0-x86_64.iso", "vmlinuz", true),
-	Entry("returns s390x kernel correctly", "/boot-artifacts/kernel", "s390x", "4.18.1", "/data/rhcos-full-iso-4.18.1-418.94.202502100215-0-s390x.iso", "kernel.img", true),
-	Entry("fails for an invalid artifact", "/boot-artifacts/asdf", "x86_64", "4.19.0", "/data/rhcos-full-iso-4.19.0-419.96.202502102012-0-x86_64.iso", "", false),
-	Entry("fails for an incorrect path", "/wrong-path/rootfs", "x86_64", "4.18.1", "/data/rhcos-full-iso-4.18.1-418.94.202502100215-0-x86_64.iso", "", false),
-	Entry("returns generic.ins correctly", "/boot-artifacts/ins-file", "s390x", "4.18.1", "/data/rhcos-full-iso-4.18.1-418.94.202502100215-0-s390x.iso", "generic.ins", true),
-	Entry("fails generic.ins incorrect arch", "/boot-artifacts/ins-file", "x86_64", "4.19.0", "/data/rhcos-full-iso-4.19.0-419.96.202502102012-0-x86_64.iso", "", false),
+	Entry("returns rootfs correctly", "/boot-artifacts/rootfs", "x86_64", "rootfs.img", true),
+	Entry("returns kernel correctly", "/boot-artifacts/kernel", "x86_64", "vmlinuz", true),
+	Entry("fails for an invalid artifact", "/boot-artifacts/asdf", "x86_64", "", false),
+	Entry("fails for an incorrect path", "/wrong-path/rootfs", "x86_64", "", false),
+	Entry("returns generic.ins correctly", "/boot-artifacts/ins-file", "s390x", "generic.ins", true),
+	Entry("fails generic.ins incorrect arch", "/boot-artifacts/ins-file", "x86_64", "", false),
+)
+
+var _ = DescribeTable("getArtifactFilePath",
+	func(artifact, expectedPath string) {
+		Expect(getArtifactFilePath(artifact)).To(Equal(expectedPath))
+	},
+	Entry("returns correct path for kernel", "kernel", "/images/pxeboot/kernel"),
+	Entry("returns correct path for initrd", "initrd.img", "/images/pxeboot/initrd.img"),
+	Entry("returns correct path for rootfs", "rootfs.img", "/images/pxeboot/rootfs.img"),
+	Entry("returns correct path for generic.ins (s390x specific)", "generic.ins", "/generic.ins"),
 )

--- a/internal/handlers/boot_artifacts_test.go
+++ b/internal/handlers/boot_artifacts_test.go
@@ -150,8 +150,8 @@ var _ = Describe("ServeHTTP", func() {
 })
 
 var _ = DescribeTable("parseArtifact",
-	func(path, arch, artifact string, success bool) {
-		a, err := parseArtifact(path, arch)
+	func(path, arch, version, artifact string, success bool) {
+		a, err := parseArtifact(path, arch, version)
 		if success {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(a).To(Equal(artifact))
@@ -159,11 +159,11 @@ var _ = DescribeTable("parseArtifact",
 			Expect(err).To(HaveOccurred())
 		}
 	},
-	Entry("returns rootfs correctly", "/boot-artifacts/rootfs", "x86_64", "rootfs.img", true),
-	Entry("returns kernel correctly", "/boot-artifacts/kernel", "x86_64", "vmlinuz", true),
-	Entry("returns s390x kernel correctly", "/boot-artifacts/kernel", "s390x", "kernel.img", true),
-	Entry("fails for an invalid artifact", "/boot-artifacts/asdf", "x86_64", "", false),
-	Entry("fails for an incorrect path", "/wrong-path/rootfs", "x86_64", "", false),
-	Entry("returns generic.ins correctly", "/boot-artifacts/ins-file", "s390x", "generic.ins", true),
-	Entry("fails generic.ins incorrect arch", "/boot-artifacts/ins-file", "x86_64", "", false),
+	Entry("returns rootfs correctly", "/boot-artifacts/rootfs", "x86_64", "4.18.0", "rootfs.img", true),
+	Entry("returns kernel correctly", "/boot-artifacts/kernel", "x86_64", "4.19.0", "vmlinuz", true),
+	Entry("returns s390x kernel correctly", "/boot-artifacts/kernel", "s390x", "4.18.0", "kernel.img", true),
+	Entry("fails for an invalid artifact", "/boot-artifacts/asdf", "x86_64", "4.19.0", "", false),
+	Entry("fails for an incorrect path", "/wrong-path/rootfs", "x86_64", "4.18.0", "", false),
+	Entry("returns generic.ins correctly", "/boot-artifacts/ins-file", "s390x", "4.18.0", "generic.ins", true),
+	Entry("fails generic.ins incorrect arch", "/boot-artifacts/ins-file", "x86_64", "4.19.0", "", false),
 )

--- a/internal/handlers/boot_artifacts_test.go
+++ b/internal/handlers/boot_artifacts_test.go
@@ -150,8 +150,8 @@ var _ = Describe("ServeHTTP", func() {
 })
 
 var _ = DescribeTable("parseArtifact",
-	func(path, arch, version, artifact string, success bool) {
-		a, err := parseArtifact(path, arch, version)
+	func(path, arch, version, isoFileName, artifact string, success bool) {
+		a, err := parseArtifact(path, arch, version, isoFileName)
 		if success {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(a).To(Equal(artifact))
@@ -159,11 +159,11 @@ var _ = DescribeTable("parseArtifact",
 			Expect(err).To(HaveOccurred())
 		}
 	},
-	Entry("returns rootfs correctly", "/boot-artifacts/rootfs", "x86_64", "4.18.0", "rootfs.img", true),
-	Entry("returns kernel correctly", "/boot-artifacts/kernel", "x86_64", "4.19.0", "vmlinuz", true),
-	Entry("returns s390x kernel correctly", "/boot-artifacts/kernel", "s390x", "4.18.0", "kernel.img", true),
-	Entry("fails for an invalid artifact", "/boot-artifacts/asdf", "x86_64", "4.19.0", "", false),
-	Entry("fails for an incorrect path", "/wrong-path/rootfs", "x86_64", "4.18.0", "", false),
-	Entry("returns generic.ins correctly", "/boot-artifacts/ins-file", "s390x", "4.18.0", "generic.ins", true),
-	Entry("fails generic.ins incorrect arch", "/boot-artifacts/ins-file", "x86_64", "4.19.0", "", false),
+	Entry("returns rootfs correctly", "/boot-artifacts/rootfs", "x86_64", "4.18.1", "/data/rhcos-full-iso-4.18.1-418.94.202502100215-0-x86_64.iso", "rootfs.img", true),
+	Entry("returns kernel correctly", "/boot-artifacts/kernel", "x86_64", "4.19.0", "/data/rhcos-full-iso-4.19.0-419.96.202502102012-0-x86_64.iso", "vmlinuz", true),
+	Entry("returns s390x kernel correctly", "/boot-artifacts/kernel", "s390x", "4.18.1", "/data/rhcos-full-iso-4.18.1-418.94.202502100215-0-s390x.iso", "kernel.img", true),
+	Entry("fails for an invalid artifact", "/boot-artifacts/asdf", "x86_64", "4.19.0", "/data/rhcos-full-iso-4.19.0-419.96.202502102012-0-x86_64.iso", "", false),
+	Entry("fails for an incorrect path", "/wrong-path/rootfs", "x86_64", "4.18.1", "/data/rhcos-full-iso-4.18.1-418.94.202502100215-0-x86_64.iso", "", false),
+	Entry("returns generic.ins correctly", "/boot-artifacts/ins-file", "s390x", "4.18.1", "/data/rhcos-full-iso-4.18.1-418.94.202502100215-0-s390x.iso", "generic.ins", true),
+	Entry("fails generic.ins incorrect arch", "/boot-artifacts/ins-file", "x86_64", "4.19.0", "/data/rhcos-full-iso-4.19.0-419.96.202502102012-0-x86_64.iso", "", false),
 )


### PR DESCRIPTION
Fixing artifact name issue for vmlinuz in  latest rhelVersions ( starting from 9.6 ) 

- Updated boot_artifacts.go to change artifact name to vmliuz from kernel.img based on RHCOS version

## Description

-  Starting from RHEL9.6 , artifact name for kernel has  changed to vmliuz from kernel.img. this is breaking the existing flow in Hosted Control Plane and Assisted Installer.

- Updated the logic to change the artifact name based the RHEL Version. 



## How was this code tested?

- Built a test image with assisted-image-service 
- Using this test image, created AgentServiceConfig and InfraEnv objects, and validated the images generated in InfraEnv.


## Assignees

@AmadeusPodvratnik 

cc @v78singh 
cc @phani2898 

## Links
https://issues.redhat.com/browse/OCPBUGS-51209


## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
