### PR TITLE
MGMT-20597: Add nmstatectl to initrd for PXE provisioning

### DIFF
--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -171,7 +171,9 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"]).Return(nil)
+				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
@@ -247,7 +249,9 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"]).Return(nil)
+				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
@@ -274,7 +278,9 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"]).Return(nil)
+				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
@@ -295,7 +301,9 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"]).Return(nil)
+				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
@@ -347,7 +355,9 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"]).Return(fmt.Errorf("minimal iso creation failed"))
+				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(fmt.Errorf("minimal iso creation failed"))
 				Expect(is.Populate(ctx)).NotTo(Succeed())
 			})
 
@@ -365,7 +375,9 @@ var _ = Context("with a data directory configured", func() {
 				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"]).Return(nil)
+				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 			})
 
@@ -380,7 +392,9 @@ var _ = Context("with a data directory configured", func() {
 				Expect(os.WriteFile(minimalPath, []byte("minimalisocontent"), 0600)).To(Succeed())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(fullPath, rootfs, "x86_64", minimalPath, version["openshift_version"]).Return(nil)
+				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				mockEditor.EXPECT().CreateMinimalISOTemplate(fullPath, rootfs, "x86_64", minimalPath, version["openshift_version"], nmstatectlPath).Return(nil)
 
 				Expect(is.Populate(ctx)).To(Succeed())
 			})
@@ -398,7 +412,9 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, versionPatch["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), versionPatch["openshift_version"]).Return(nil)
+				nmstatectlPath, err := is.NmstatectlPathForParams(versionPatch["openshift_version"], versionPatch["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), versionPatch["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8.1-48.84.202109241901-0-x86_64.iso"))
@@ -421,7 +437,9 @@ var _ = Context("with a data directory configured", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					rootfs := fmt.Sprintf(rootfsURL, versionPatch["openshift_version"])
-					mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), versionPatch["openshift_version"]).Return(nil)
+					nmstatectlPath, err := is.NmstatectlPathForParams(versionPatch["openshift_version"], versionPatch["cpu_architecture"])
+					Expect(err).NotTo(HaveOccurred())
+					mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), versionPatch["openshift_version"], nmstatectlPath).Return(nil)
 					Expect(is.Populate(ctx)).To(Succeed())
 				}
 			})
@@ -442,7 +460,9 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"]).Return(nil)
+				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				_, err = os.Stat(oldISOPath)
@@ -471,8 +491,9 @@ var _ = Context("with a data directory configured", func() {
 			It("fails when imageServiceBaseURL is not set", func() {
 				is, err := NewImageStore(mockEditor, dataDir, "", false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
 				Expect(err).NotTo(HaveOccurred())
-
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "", "x86_64", gomock.Any(), gomock.Any()).Return(nil)
+				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "", "x86_64", gomock.Any(), gomock.Any(), nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).NotTo(Succeed())
 			})
 
@@ -490,7 +511,9 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				rootfs := fmt.Sprintf("https://images.example.com/api/assisted-images/boot-artifacts/rootfs?arch=x86_64&version=%s", version["openshift_version"])
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), gomock.Any()).Return(nil)
+				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), gomock.Any(), nmstatectlPath).Return(nil)
 				err = is.Populate(ctx)
 				Expect(err).ToNot(Succeed())
 				Expect(err.Error()).To(Equal("failed to build rootfs URL: parse \":\": missing protocol scheme"))

--- a/pkg/imagestore/mock_imagestore.go
+++ b/pkg/imagestore/mock_imagestore.go
@@ -48,6 +48,21 @@ func (mr *MockImageStoreMockRecorder) HaveVersion(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HaveVersion", reflect.TypeOf((*MockImageStore)(nil).HaveVersion), arg0, arg1)
 }
 
+// NmstatectlPathForParams mocks base method.
+func (m *MockImageStore) NmstatectlPathForParams(arg0, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NmstatectlPathForParams", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NmstatectlPathForParams indicates an expected call of NmstatectlPathForParams.
+func (mr *MockImageStoreMockRecorder) NmstatectlPathForParams(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NmstatectlPathForParams", reflect.TypeOf((*MockImageStore)(nil).NmstatectlPathForParams), arg0, arg1)
+}
+
 // PathForParams mocks base method.
 func (m *MockImageStore) PathForParams(arg0, arg1, arg2 string) string {
 	m.ctrl.T.Helper()

--- a/pkg/isoeditor/mock_editor.go
+++ b/pkg/isoeditor/mock_editor.go
@@ -34,15 +34,15 @@ func (m *MockEditor) EXPECT() *MockEditorMockRecorder {
 }
 
 // CreateMinimalISOTemplate mocks base method.
-func (m *MockEditor) CreateMinimalISOTemplate(arg0, arg1, arg2, arg3, arg4 string) error {
+func (m *MockEditor) CreateMinimalISOTemplate(arg0, arg1, arg2, arg3, arg4, arg5 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMinimalISOTemplate", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "CreateMinimalISOTemplate", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateMinimalISOTemplate indicates an expected call of CreateMinimalISOTemplate.
-func (mr *MockEditorMockRecorder) CreateMinimalISOTemplate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockEditorMockRecorder) CreateMinimalISOTemplate(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMinimalISOTemplate", reflect.TypeOf((*MockEditor)(nil).CreateMinimalISOTemplate), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMinimalISOTemplate", reflect.TypeOf((*MockEditor)(nil).CreateMinimalISOTemplate), arg0, arg1, arg2, arg3, arg4, arg5)
 }

--- a/pkg/isoeditor/mock_nmstate_handler.go
+++ b/pkg/isoeditor/mock_nmstate_handler.go
@@ -34,15 +34,15 @@ func (m *MockNmstateHandler) EXPECT() *MockNmstateHandlerMockRecorder {
 }
 
 // CreateNmstateRamDisk mocks base method.
-func (m *MockNmstateHandler) CreateNmstateRamDisk(arg0, arg1 string) error {
+func (m *MockNmstateHandler) CreateNmstateRamDisk(arg0, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNmstateRamDisk", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateNmstateRamDisk", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateNmstateRamDisk indicates an expected call of CreateNmstateRamDisk.
-func (mr *MockNmstateHandlerMockRecorder) CreateNmstateRamDisk(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNmstateHandlerMockRecorder) CreateNmstateRamDisk(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNmstateRamDisk", reflect.TypeOf((*MockNmstateHandler)(nil).CreateNmstateRamDisk), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNmstateRamDisk", reflect.TypeOf((*MockNmstateHandler)(nil).CreateNmstateRamDisk), arg0, arg1, arg2)
 }

--- a/pkg/isoeditor/nmstate_handler_test.go
+++ b/pkg/isoeditor/nmstate_handler_test.go
@@ -34,25 +34,28 @@ var _ = Context("with test files", func() {
 
 	Describe("CreateNmstateRamDisk", func() {
 		var (
-			extractDir, ramDiskPath string
-			err                     error
-			nmstateHandler          NmstateHandler
-			ctrl                    *gomock.Controller
-			mockExecuter            *MockExecuter
+			extractDir, ramDiskPath, nmstatectlPath, nmstatectlPathForCaching string
+			err                                                               error
+			nmstateHandler                                                    NmstateHandler
+			ctrl                                                              *gomock.Controller
+			mockExecuter                                                      *MockExecuter
 		)
 
 		BeforeEach(func() {
 			extractDir = os.TempDir()
+
 			nmstateDir := filepath.Join(extractDir, "nmstate", "squashfs-root")
 			err = os.MkdirAll(nmstateDir, os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
-			nmstatectlPath := filepath.Join(nmstateDir, "nmstatectl")
+			nmstatectlPath = filepath.Join(nmstateDir, "nmstatectl")
 			_, err := os.Create(nmstatectlPath)
 			Expect(err).ToNot(HaveOccurred())
 
 			ramDisk, err := os.CreateTemp(extractDir, "nmstate.img")
 			Expect(err).ToNot(HaveOccurred())
+
+			nmstatectlPathForCaching = filepath.Join(workDir, "nmstatectl-openshiftVersion-version-arch")
 
 			ramDiskPath = ramDisk.Name()
 
@@ -64,10 +67,11 @@ var _ = Context("with test files", func() {
 
 		AfterEach(func() {
 			os.Remove(extractDir)
+			os.Remove(ramDiskPath)
 		})
 
 		It("ram disk created successfully", func() {
-			err := nmstateHandler.CreateNmstateRamDisk("", ramDiskPath)
+			err := nmstateHandler.CreateNmstateRamDisk("", ramDiskPath, nmstatectlPathForCaching)
 			Expect(err).ToNot(HaveOccurred())
 
 			exists, err := fileExists(ramDiskPath)

--- a/pkg/isoeditor/rhcos.go
+++ b/pkg/isoeditor/rhcos.go
@@ -20,7 +20,7 @@ const (
 
 //go:generate mockgen -package=isoeditor -destination=mock_editor.go . Editor
 type Editor interface {
-	CreateMinimalISOTemplate(fullISOPath, rootFSURL, arch, minimalISOPath, openshiftVersion string) error
+	CreateMinimalISOTemplate(fullISOPath, rootFSURL, arch, minimalISOPath, openshiftVersion, nmstatectlPath string) error
 }
 
 type rhcosEditor struct {
@@ -71,7 +71,7 @@ func CreateMinimalISO(extractDir, volumeID, rootFSURL, arch, minimalISOPath stri
 }
 
 // CreateMinimalISOTemplate Creates the template minimal iso by removing the rootfs and adding the url
-func (e *rhcosEditor) CreateMinimalISOTemplate(fullISOPath, rootFSURL, arch, minimalISOPath, openshiftVersion string) error {
+func (e *rhcosEditor) CreateMinimalISOTemplate(fullISOPath, rootFSURL, arch, minimalISOPath, openshiftVersion, nmstatectlPath string) error {
 	extractDir, err := os.MkdirTemp(e.workDir, "isoutil")
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func (e *rhcosEditor) CreateMinimalISOTemplate(fullISOPath, rootFSURL, arch, min
 
 	if versionOK {
 		rootfsPath := filepath.Join(extractDir, "images/pxeboot/rootfs.img")
-		err = e.nmstateHandler.CreateNmstateRamDisk(rootfsPath, ramDiskPath)
+		err = e.nmstateHandler.CreateNmstateRamDisk(rootfsPath, ramDiskPath, nmstatectlPath)
 		if err != nil {
 			return fmt.Errorf("failed to create nmstate ram disk for arch %s: %v", arch, err)
 		}

--- a/pkg/isoeditor/rhcos_test.go
+++ b/pkg/isoeditor/rhcos_test.go
@@ -23,6 +23,7 @@ var _ = Context("with test files", func() {
 		filesDir           string
 		workDir            string
 		minimalISOPath     string
+		nmstatectlPath     string
 		volumeID           = "Assisted123"
 		ctrl               *gomock.Controller
 		mockNmstateHandler *MockNmstateHandler
@@ -50,12 +51,12 @@ var _ = Context("with test files", func() {
 		workDir, err = os.MkdirTemp("", "testisoeditor")
 		Expect(err).NotTo(HaveOccurred())
 		minimalISOPath = filepath.Join(workDir, "minimal.iso")
-
+		nmstatectlPath = filepath.Join(workDir, "nmstatectl-for-caching")
 		ctrl = gomock.NewController(GinkgoT())
 		mockNmstateHandler = NewMockNmstateHandler(ctrl)
 		mockExecuter = NewMockExecuter(ctrl)
 		mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("some string", nil).Times(3)
-		mockNmstateHandler.EXPECT().CreateNmstateRamDisk(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockNmstateHandler.EXPECT().CreateNmstateRamDisk(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	})
 
 	AfterEach(func() {
@@ -67,13 +68,13 @@ var _ = Context("with test files", func() {
 	Describe("CreateMinimalISOTemplate", func() {
 		It("iso created successfully", func() {
 			editor := NewEditor(workDir, mockNmstateHandler)
-			err := editor.CreateMinimalISOTemplate(isoFile, testRootFSURL, "x86_64", minimalISOPath, "4.17")
+			err := editor.CreateMinimalISOTemplate(isoFile, testRootFSURL, "x86_64", minimalISOPath, "4.17", nmstatectlPath)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("missing iso file", func() {
 			editor := NewEditor(workDir, mockNmstateHandler)
-			err := editor.CreateMinimalISOTemplate("invalid", testRootFSURL, "x86_64", minimalISOPath, "4.18.0-ec.0")
+			err := editor.CreateMinimalISOTemplate("invalid", testRootFSURL, "x86_64", minimalISOPath, "4.18.0-ec.0", nmstatectlPath)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -81,13 +82,13 @@ var _ = Context("with test files", func() {
 	Describe("CreateFCOSMinimalISOTemplate", func() {
 		It("iso created successfully", func() {
 			editor := NewEditor(workDir, mockNmstateHandler)
-			err := editor.CreateMinimalISOTemplate(isoFile, testFCOSRootFSURL, "x86_64", minimalISOPath, "4.17")
+			err := editor.CreateMinimalISOTemplate(isoFile, testFCOSRootFSURL, "x86_64", minimalISOPath, "4.17", nmstatectlPath)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("missing iso file", func() {
 			editor := NewEditor(workDir, mockNmstateHandler)
-			err := editor.CreateMinimalISOTemplate("invalid", testFCOSRootFSURL, "x86_64", minimalISOPath, "4.18.0-ec.0")
+			err := editor.CreateMinimalISOTemplate("invalid", testFCOSRootFSURL, "x86_64", minimalISOPath, "4.18.0-ec.0", nmstatectlPath)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
## Description
When booting via PXE with static networking, connectivity could not be established, which resulted in failure to fetch the rootfs. The root cause is the absence of nmstatectl in the initrd. This PR solve this.

**Notes:** 
1. This PR triggered a high-severity warning from Snyk related to os.Open. Although the suggested mitigation was applied in the PR, the warning still persists. That said, it doesn’t appear to be a real security risk because:

-  The input parameters (version and arch) are validated.
- Even if someone tried to craft values to access files outside the intended directory, an additional check was added to ensure that the parent directory of nmstatectlPath matches the expected working directory - and the code rejects the path if it doesn’t.

2. The reason we're placing the nmstatectl cache file creation as part of the minimal ISO creation - despite it not being directly related - is because in that flow we already have access to the rootfs URL and extract the nmstatectl binary there. While it may not be the most logically accurate place, it's the more practical choice, as creating a separate caching flow just for PXE would be redundant.

<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

1. Select static networking when creating the cluster.
3. Generate the PXE script.
4. Extract the initrd and kernel URLs from the PXE script and download the images.
5. Boot from the artifacts (initrd.img and kernel.img) using the kargs provided in the PXE script.
6. Disable DHCP by adding the following karg: ip=::::<interface-name>:none
7. Start the boot process

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @danielerez  
/cc @carbonin 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [X] Title and description added to both, commit and PR
- [X] Relevant issues have been associated
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
