### PR TITLE
MGMT-21137: Allow adding Ignition system configs

### DIFF
--- a/pkg/isoeditor/ignition.go
+++ b/pkg/isoeditor/ignition.go
@@ -2,20 +2,39 @@ package isoeditor
 
 import (
 	"bytes"
+	"fmt"
+	"path"
+	"strings"
 )
 
 type IgnitionContent struct {
-	Config []byte
+	Config        []byte
+	SystemConfigs map[string][]byte
 }
 
 func (ic *IgnitionContent) Archive() (*bytes.Reader, error) {
-	compressedCpio, err := generateCompressedCPIO([]fileEntry{
-		{
+	var files []fileEntry
+
+	if len(ic.Config) > 0 {
+		files = append(files, fileEntry{
 			Content: ic.Config,
 			Path:    "config.ign",
 			Mode:    0o100_644,
-		},
-	})
+		})
+	}
+
+	for filename, content := range ic.SystemConfigs {
+		if strings.Contains(filename, "/") {
+			return nil, fmt.Errorf("system config filename %q contains path separators", filename)
+		}
+		files = append(files, fileEntry{
+			Content: content,
+			Path:    path.Join("usr", "lib", "ignition", "base.d", filename),
+			Mode:    0o100_644,
+		})
+	}
+
+	compressedCpio, err := generateCompressedCPIO(files)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/isoeditor/ignition.go
+++ b/pkg/isoeditor/ignition.go
@@ -9,7 +9,13 @@ type IgnitionContent struct {
 }
 
 func (ic *IgnitionContent) Archive() (*bytes.Reader, error) {
-	compressedCpio, err := generateCompressedCPIO(ic.Config, "config.ign", 0o100_644)
+	compressedCpio, err := generateCompressedCPIO([]fileEntry{
+		{
+			Content: ic.Config,
+			Path:    "config.ign",
+			Mode:    0o100_644,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/isoeditor/ignition_image_test.go
+++ b/pkg/isoeditor/ignition_image_test.go
@@ -33,7 +33,7 @@ var _ = Describe("IgnitionContent.Archive", func() {
 	})
 
 	It("streams the ignition image", func() {
-		content := IgnitionContent{ignitionContent}
+		content := IgnitionContent{Config: ignitionContent}
 
 		outputs, err := NewIgnitionImageReader(isoFile, &content)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/isoeditor/ignition_test.go
+++ b/pkg/isoeditor/ignition_test.go
@@ -21,7 +21,7 @@ var _ = Describe("IgnitionContent.Archive", func() {
 	)
 
 	It("converts the ignition to a compressed CPIO archive", func() {
-		content := IgnitionContent{ignitionContent}
+		content := IgnitionContent{Config: ignitionContent}
 
 		data, err := content.Archive()
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/isoeditor/ignition_test.go
+++ b/pkg/isoeditor/ignition_test.go
@@ -1,8 +1,11 @@
 package isoeditor
 
 import (
+	"bytes"
+	"compress/gzip"
 	"io"
 
+	"github.com/cavaliercoder/go-cpio"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -20,6 +23,28 @@ var _ = Describe("IgnitionContent.Archive", func() {
 			0, 255, 255, 191, 236, 44, 242, 12, 1, 0, 0, 0}
 	)
 
+	extractCPIOFiles := func(archiveBytes []byte) map[string][]byte {
+		gzReader, err := gzip.NewReader(bytes.NewReader(archiveBytes))
+		Expect(err).NotTo(HaveOccurred())
+		defer gzReader.Close()
+
+		cpioReader := cpio.NewReader(gzReader)
+		files := make(map[string][]byte)
+
+		for {
+			header, err := cpioReader.Next()
+			if err == io.EOF {
+				break
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			content, err := io.ReadAll(cpioReader)
+			Expect(err).NotTo(HaveOccurred())
+			files[header.Name] = content
+		}
+		return files
+	}
+
 	It("converts the ignition to a compressed CPIO archive", func() {
 		content := IgnitionContent{Config: ignitionContent}
 
@@ -30,5 +55,79 @@ var _ = Describe("IgnitionContent.Archive", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ignitionBytes).To(Equal(ignitionArchiveBytes))
 		Expect(len(ignitionBytes) % 4).To(Equal(0))
+	})
+
+	It("creates archive with system configs only", func() {
+		systemConfig1 := []byte(`{"ignition": {"version": "3.1.0"}}`)
+		systemConfig2 := []byte(`{"passwd": {"users": []}}`)
+
+		content := IgnitionContent{
+			SystemConfigs: map[string][]byte{
+				"10-network.ign": systemConfig1,
+				"20-users.ign":   systemConfig2,
+			},
+		}
+
+		data, err := content.Archive()
+		Expect(err).NotTo(HaveOccurred())
+
+		archiveBytes, err := io.ReadAll(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(archiveBytes) % 4).To(Equal(0))
+
+		files := extractCPIOFiles(archiveBytes)
+		Expect(files).To(HaveLen(2))
+		Expect(files["usr/lib/ignition/base.d/10-network.ign"]).To(Equal(systemConfig1))
+		Expect(files["usr/lib/ignition/base.d/20-users.ign"]).To(Equal(systemConfig2))
+	})
+
+	It("creates archive with both main config and system configs", func() {
+		systemConfig := []byte(`{"storage": {"files": []}}`)
+
+		content := IgnitionContent{
+			Config: ignitionContent,
+			SystemConfigs: map[string][]byte{
+				"30-storage.ign": systemConfig,
+			},
+		}
+
+		data, err := content.Archive()
+		Expect(err).NotTo(HaveOccurred())
+
+		archiveBytes, err := io.ReadAll(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(archiveBytes) % 4).To(Equal(0))
+
+		files := extractCPIOFiles(archiveBytes)
+		Expect(files).To(HaveLen(2))
+		Expect(files["config.ign"]).To(Equal(ignitionContent))
+		Expect(files["usr/lib/ignition/base.d/30-storage.ign"]).To(Equal(systemConfig))
+	})
+
+	It("returns error when system config filename contains path separator", func() {
+		content := IgnitionContent{
+			SystemConfigs: map[string][]byte{
+				"subdir/50-bad.ign": []byte("content"),
+			},
+		}
+
+		_, err := content.Archive()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("contains path separators"))
+		Expect(err.Error()).To(ContainSubstring("subdir/50-bad.ign"))
+	})
+
+	It("creates empty archive when no configs provided", func() {
+		content := IgnitionContent{}
+
+		data, err := content.Archive()
+		Expect(err).NotTo(HaveOccurred())
+
+		archiveBytes, err := io.ReadAll(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(archiveBytes) % 4).To(Equal(0))
+
+		files := extractCPIOFiles(archiveBytes)
+		Expect(files).To(HaveLen(0))
 	})
 })

--- a/pkg/isoeditor/initramfs_test.go
+++ b/pkg/isoeditor/initramfs_test.go
@@ -27,7 +27,7 @@ var _ = Describe("NewInitRamFSStreamReader", func() {
 	initrdPath := filepath.Join(filesDir, "images/ignition.img")
 
 	It("appends the ignition", func() {
-		streamReader, err := NewInitRamFSStreamReader(initrdPath, &IgnitionContent{ignitionContent})
+		streamReader, err := NewInitRamFSStreamReader(initrdPath, &IgnitionContent{Config: ignitionContent})
 		Expect(err).NotTo(HaveOccurred())
 
 		var output, expected strings.Builder

--- a/pkg/isoeditor/initrd_addrsize_test.go
+++ b/pkg/isoeditor/initrd_addrsize_test.go
@@ -19,7 +19,7 @@ var _ = Describe("NewInitrdAddrsizeReader", func() {
 	initrdPath := filepath.Join(filesDir, "images/ignition.img")
 	addrsizePath := filepath.Join(filesDir, "images/initrd.addrsize")
 	It("Get initrd.addrsize file", func() {
-		streamReader, err := NewInitRamFSStreamReader(initrdPath, &IgnitionContent{ignitionContent})
+		streamReader, err := NewInitRamFSStreamReader(initrdPath, &IgnitionContent{Config: ignitionContent})
 		Expect(err).NotTo(HaveOccurred())
 
 		addrsizeFile, err := NewInitrdAddrsizeReader(addrsizePath, streamReader)

--- a/pkg/isoeditor/nmstate_handler.go
+++ b/pkg/isoeditor/nmstate_handler.go
@@ -85,7 +85,13 @@ func (n *nmstateHandler) buildNmstateCpioArchive(rootfsPath string) ([]byte, err
 	}
 
 	// Create a compressed RAM disk image with the nmstatectl binary
-	compressedCpio, err := generateCompressedCPIO(nmstateBinContent, NmstatectlPathInRamdisk, 0o100_755)
+	compressedCpio, err := generateCompressedCPIO([]fileEntry{
+		{
+			Content: nmstateBinContent,
+			Path:    NmstatectlPathInRamdisk,
+			Mode:    0o100_755,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/isoeditor/stream_test.go
+++ b/pkg/isoeditor/stream_test.go
@@ -54,7 +54,7 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 	}
 
 	It("embeds the ignition with no ramdisk content", func() {
-		streamReader, err := NewRHCOSStreamReader(isoFile, &IgnitionContent{ignitionContent}, nil, nil)
+		streamReader, err := NewRHCOSStreamReader(isoFile, &IgnitionContent{Config: ignitionContent}, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		f, err := os.CreateTemp(filesDir, "streamed*.iso")
@@ -69,7 +69,7 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 
 	It("embeds the ignition and ramdisk content", func() {
 		initrdContent := []byte("someramdiskcontent")
-		streamReader, err := NewRHCOSStreamReader(isoFile, &IgnitionContent{ignitionContent}, initrdContent, nil)
+		streamReader, err := NewRHCOSStreamReader(isoFile, &IgnitionContent{Config: ignitionContent}, initrdContent, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		f, err := os.CreateTemp(filesDir, "streamed*.iso")
@@ -84,7 +84,7 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 	})
 	It("embeds the ignition and kargs content", func() {
 		kargs := []byte(" p1 p2 p3 p4\n")
-		streamReader, err := NewRHCOSStreamReader(isoFile, &IgnitionContent{ignitionContent}, nil, kargs)
+		streamReader, err := NewRHCOSStreamReader(isoFile, &IgnitionContent{Config: ignitionContent}, nil, kargs)
 		Expect(err).NotTo(HaveOccurred())
 
 		f, err := os.CreateTemp(filesDir, "streamed*.iso")
@@ -111,7 +111,7 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 		}()
 
 		// Copy the output ISO to a file:
-		outputReader, err := NewRHCOSStreamReader(inputFile, &IgnitionContent{ignitionContent}, nil, nil)
+		outputReader, err := NewRHCOSStreamReader(inputFile, &IgnitionContent{Config: ignitionContent}, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 		defer func() {
 			Expect(outputReader.Close()).To(Succeed())


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->
Allow IgnitionContent (from which the CPIO archive is generated) to contain both the user config and/or system config.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->
Unit tests


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @danielerez 

## Links
<!--
List any applicable links to related PRs or issues
-->
[MGMT-21137](https://issues.redhat.com/browse/MGMT-21137)

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
