### PR TITLE
MGMT-21276: Add nmstatectl binary for the s390x arch

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -19,8 +19,10 @@ import (
 
 	"github.com/cavaliercoder/go-cpio"
 	diskfs "github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/filesystem"
 	"github.com/google/uuid"
 	"github.com/onsi/gomega/ghttp"
+	"github.com/openshift/assisted-image-service/internal/common"
 	"github.com/openshift/assisted-image-service/internal/handlers"
 	"github.com/openshift/assisted-image-service/pkg/imagestore"
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
@@ -76,6 +78,18 @@ var (
 			"cpu_architecture":  "x86_64",
 			"url":               "https://okd-scos.s3.amazonaws.com/okd-scos/builds/413.9.202302280609-0/x86_64/scos-413.9.202302280609-0-live.x86_64.iso",
 			"version":           "x86_64-latest",
+		},
+		{
+			"openshift_version": "4.18",
+			"cpu_architecture":  "s390x",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.18/4.18.1/rhcos-4.18.1-s390x-live.s390x.iso",
+			"version":           "s390x-418",
+		},
+		{
+			"openshift_version": "4.18",
+			"cpu_architecture":  "x86_64",
+			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.18/4.18.1/rhcos-4.18.1-x86_64-live.x86_64.iso",
+			"version":           "x86_64-418",
 		},
 	}
 
@@ -235,20 +249,15 @@ var _ = Describe("Image integration tests", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					By("verifying ignition content")
-					f, err := fs.OpenFile("/images/ignition.img", os.O_RDONLY)
+					rc, err := ignitionPayloadReader(fs, version)
 					Expect(err).NotTo(HaveOccurred())
-					gzipReader, err := gzip.NewReader(f)
-					Expect(err).NotTo(HaveOccurred())
-					cpioReader := cpio.NewReader(gzipReader)
-					hdr, err := cpioReader.Next()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(hdr.Name).To(Equal("config.ign"))
-					Expect(hdr.Size).To(Equal(int64(len(tc.expectedIgnition))))
-					content, err := io.ReadAll(cpioReader)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(content).To(Equal(tc.expectedIgnition))
+					defer rc.Close()
 
-					if tc.expectedRamdisk != nil {
+					got, err := readIgnitionContentFromGzCpio(rc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(got).To(Equal(tc.expectedIgnition))
+
+					if len(tc.expectedRamdisk) > 0 {
 						By("verifying ramdisk content")
 						f, err := fs.OpenFile("/images/assisted_installer_custom.img", os.O_RDONLY)
 						Expect(err).NotTo(HaveOccurred())
@@ -272,6 +281,82 @@ var _ = Describe("Image integration tests", func() {
 				})
 			}
 		})
+		Context("nmstate archive verification - "+tc.name, func() {
+			BeforeEach(func() {
+				imageID = uuid.New().String()
+
+				// Set up assisted service
+				assistedServer = ghttp.NewServer()
+				u, err := url.Parse(assistedServer.URL())
+				Expect(err).NotTo(HaveOccurred())
+
+				// pxe-initrd path: ignition without discovery_iso_type
+				assistedServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/downloads/files", imageID), "file_name=discovery.ign"),
+						ghttp.RespondWith(http.StatusOK, tc.expectedIgnition),
+					),
+				)
+				// pxe-initrd path: minimal-initrd always requested; 200 when provided, else 204
+				if len(tc.expectedRamdisk) > 0 {
+					assistedServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/downloads/minimal-initrd", imageID)),
+							ghttp.RespondWith(http.StatusOK, tc.expectedRamdisk),
+						),
+					)
+				} else {
+					assistedServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/downloads/minimal-initrd", imageID)),
+							ghttp.RespondWith(http.StatusNoContent, nil),
+						),
+					)
+				}
+
+				asc, err := handlers.NewAssistedServiceClient(u.Scheme, u.Host, "")
+				Expect(err).NotTo(HaveOccurred())
+
+				mdw := middleware.New(middleware.Config{})
+				imageServer = httptest.NewServer(handlers.NewImageHandler(imageStore, asc, 1, mdw))
+				imageClient = imageServer.Client()
+			})
+			AfterEach(func() {
+				assistedServer.Close()
+				imageServer.Close()
+			})
+
+			for i := range versions {
+				version := versions[i]
+
+				It("includes nmstate for "+version["openshift_version"]+" "+version["cpu_architecture"], func() {
+					ok, err := common.VersionGreaterOrEqual(version["openshift_version"], isoeditor.MinimalVersionForNmstatectl)
+					Expect(err).NotTo(HaveOccurred())
+
+					if len(tc.expectedRamdisk) <= 0 || !ok {
+						Skip(fmt.Sprintf("skipping test %s due to ocp version < 4.18 or ramdisk isn't present", tc.name))
+					}
+
+					path := fmt.Sprintf("/images/%s/pxe-initrd?version=%s&arch=%s",
+						imageID, version["openshift_version"], version["cpu_architecture"])
+					resp2, err := imageClient.Get(imageServer.URL + path)
+					Expect(err).NotTo(HaveOccurred())
+					defer resp2.Body.Close()
+					Expect(resp2.StatusCode).To(Equal(http.StatusOK))
+
+					initrdBytes, err := io.ReadAll(resp2.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					nmPath, err := imageStore.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+					Expect(err).NotTo(HaveOccurred())
+					nmBytes, err := os.ReadFile(nmPath)
+					Expect(err).NotTo(HaveOccurred())
+
+					// nmstate archive is appended last when ramdisk is present
+					Expect(bytes.HasSuffix(initrdBytes, nmBytes)).To(BeTrue(), "initrd should end with nmstate archive")
+				})
+			}
+		})
 	}
 })
 
@@ -281,7 +366,8 @@ var _ = BeforeSuite(func() {
 	imageDir, err = os.MkdirTemp("", "imagesTest")
 	Expect(err).To(BeNil())
 
-	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir, isoeditor.NewNmstateHandler(imageDir, &isoeditor.CommonExecuter{})), imageDir, imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
+	nmstateHandler := isoeditor.NewNmstateHandler(imageDir, &isoeditor.CommonExecuter{})
+	imageStore, err = imagestore.NewImageStore(isoeditor.NewEditor(imageDir, nmstateHandler), imageDir, imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nmstateHandler)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = imageStore.Populate(context.Background())
@@ -299,4 +385,71 @@ func TestIntegration(t *testing.T) {
 	}
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "image building tests")
+}
+
+func ignitionPayloadReader(fs filesystem.FileSystem, version map[string]string) (io.ReadCloser, error) {
+	ignInfoFile, err := fs.OpenFile("/coreos/igninfo.json", os.O_RDONLY)
+	if err == nil {
+		defer ignInfoFile.Close()
+
+		var ignInfoBytes []byte
+		ignInfoBytes, err = io.ReadAll(ignInfoFile)
+		if err != nil {
+			return nil, err
+		}
+		var ignInfo struct {
+			File   string `json:"file,omitempty"`
+			Length int64  `json:"length,omitempty"`
+			Offset int64  `json:"offset,omitempty"`
+		}
+		if err = json.Unmarshal(ignInfoBytes, &ignInfo); err != nil {
+			return nil, err
+		}
+
+		var containerFile filesystem.File
+		containerFile, err = fs.OpenFile(ignInfo.File, os.O_RDONLY)
+		if err != nil {
+			return nil, err
+		}
+		defer containerFile.Close()
+
+		var containerBytes []byte
+		containerBytes, err = io.ReadAll(containerFile)
+		if err != nil {
+			return nil, err
+		}
+		end := ignInfo.Offset + ignInfo.Length
+		if ignInfo.Length == 0 || end > int64(len(containerBytes)) {
+			end = int64(len(containerBytes))
+		}
+		ignitionBytes := bytes.TrimRight(containerBytes[ignInfo.Offset:end], "\x00")
+
+		return io.NopCloser(bytes.NewReader(ignitionBytes)), nil
+	}
+
+	// fallback to the default path: ignition.img
+	var f filesystem.File
+	f, err = fs.OpenFile("/images/ignition.img", os.O_RDONLY)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func readIgnitionContentFromGzCpio(r io.Reader) ([]byte, error) {
+	gr, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	defer gr.Close()
+
+	cr := cpio.NewReader(gr)
+	hdr, err := cr.Next()
+	if err != nil {
+		return nil, err
+	}
+	if hdr.Name != "config.ign" {
+		return nil, fmt.Errorf("unexpected cpio entry: %s", hdr.Name)
+	}
+	return io.ReadAll(cr)
 }

--- a/main.go
+++ b/main.go
@@ -111,15 +111,17 @@ func main() {
 		log.Fatalf("Failed to unmarshal OSImageDownloadQueryParams: %v\n", err)
 	}
 
+	nmstateHandler := isoeditor.NewNmstateHandler(Options.DataTempDir, &isoeditor.CommonExecuter{})
 	is, err := imagestore.NewImageStore(
-		isoeditor.NewEditor(Options.DataTempDir, isoeditor.NewNmstateHandler(Options.DataTempDir, &isoeditor.CommonExecuter{})),
+		isoeditor.NewEditor(Options.DataTempDir, nmstateHandler),
 		Options.DataDir,
 		Options.ImageServiceBaseURL,
 		Options.InsecureSkipVerify,
 		versions,
 		Options.OSImageDownloadTrustedCAFile,
 		osImageDownloadHeadersMap,
-		osImageDownloadQueryParamsMap)
+		osImageDownloadQueryParamsMap,
+		nmstateHandler)
 
 	if err != nil {
 		log.Fatalf("Failed to create image store: %v\n", err)

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
@@ -132,10 +133,11 @@ var _ = Context("with a data directory configured", func() {
 
 		Describe("Populate", func() {
 			var (
-				ctrl          *gomock.Controller
-				mockEditor    *isoeditor.MockEditor
-				validVolumeID = "rhcos-411.86.202210041459-0"
-				version       = map[string]string{
+				ctrl               *gomock.Controller
+				mockEditor         *isoeditor.MockEditor
+				mockNmstateHandler *isoeditor.MockNmstateHandler
+				validVolumeID      = "rhcos-411.86.202210041459-0"
+				version            = map[string]string{
 					"openshift_version": "4.8",
 					"cpu_architecture":  "x86_64",
 					"version":           "48.84.202109241901-0",
@@ -145,6 +147,7 @@ var _ = Context("with a data directory configured", func() {
 			BeforeEach(func() {
 				ctrl = gomock.NewController(GinkgoT())
 				mockEditor = isoeditor.NewMockEditor(ctrl)
+				mockNmstateHandler = isoeditor.NewMockNmstateHandler(ctrl)
 				osImageDownloadHeadersMap = map[string]string{}
 				osImageDownloadQueryParamsMap = map[string]string{}
 			})
@@ -167,7 +170,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, caCertFileName, osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, caCertFileName, osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
@@ -205,10 +208,11 @@ var _ = Context("with a data directory configured", func() {
 
 		Describe("Populate", func() {
 			var (
-				ctrl          *gomock.Controller
-				mockEditor    *isoeditor.MockEditor
-				validVolumeID = "rhcos-411.86.202210041459-0"
-				version       = map[string]string{
+				ctrl               *gomock.Controller
+				mockEditor         *isoeditor.MockEditor
+				mockNmstateHandler *isoeditor.MockNmstateHandler
+				validVolumeID      = "rhcos-411.86.202210041459-0"
+				version            = map[string]string{
 					"openshift_version": "4.8",
 					"cpu_architecture":  "x86_64",
 					"version":           "48.84.202109241901-0",
@@ -223,6 +227,7 @@ var _ = Context("with a data directory configured", func() {
 			BeforeEach(func() {
 				ctrl = gomock.NewController(GinkgoT())
 				mockEditor = isoeditor.NewMockEditor(ctrl)
+				mockNmstateHandler = isoeditor.NewMockNmstateHandler(ctrl)
 			})
 
 			isoInfo := func(id string) ([]byte, http.Header) {
@@ -245,7 +250,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
@@ -274,7 +279,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
@@ -297,7 +302,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
@@ -319,7 +324,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/fail.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(is.Populate(ctx)).NotTo(Succeed())
@@ -334,7 +339,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(is.Populate(ctx)).NotTo(Succeed())
@@ -351,7 +356,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
@@ -369,7 +374,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/dontcallthis.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
@@ -382,7 +387,7 @@ var _ = Context("with a data directory configured", func() {
 			})
 
 			It("recreates the minimal iso even when it's already present", func() {
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				fullPath := filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso")
@@ -408,7 +413,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				versionPatch["url"] = ts.URL() + "/somepatchversion.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{versionPatch}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{versionPatch}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, versionPatch["openshift_version"])
@@ -433,7 +438,7 @@ var _ = Context("with a data directory configured", func() {
 						),
 					)
 					versionPatch["url"] = ts.URL() + "/somepatchversion.iso"
-					is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{versionPatch}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+					is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{versionPatch}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 					Expect(err).NotTo(HaveOccurred())
 
 					rootfs := fmt.Sprintf(rootfsURL, versionPatch["openshift_version"])
@@ -456,7 +461,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
@@ -477,7 +482,7 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = is.Populate(ctx)
@@ -489,7 +494,7 @@ var _ = Context("with a data directory configured", func() {
 			})
 
 			It("fails when imageServiceBaseURL is not set", func() {
-				is, err := NewImageStore(mockEditor, dataDir, "", false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, "", false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
 				Expect(err).NotTo(HaveOccurred())
@@ -507,7 +512,7 @@ var _ = Context("with a data directory configured", func() {
 				)
 				version["url"] = ts.URL() + "/some.iso"
 				baseURL := ":"
-				is, err := NewImageStore(mockEditor, dataDir, baseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap)
+				is, err := NewImageStore(mockEditor, dataDir, baseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).ToNot(HaveOccurred())
 
 				rootfs := fmt.Sprintf("https://images.example.com/api/assisted-images/boot-artifacts/rootfs?arch=x86_64&version=%s", version["openshift_version"])
@@ -517,6 +522,102 @@ var _ = Context("with a data directory configured", func() {
 				err = is.Populate(ctx)
 				Expect(err).ToNot(Succeed())
 				Expect(err.Error()).To(Equal("failed to build rootfs URL: parse \":\": missing protocol scheme"))
+			})
+			It("happy flow for s390x architecture with cached nmstatectl", func() {
+				s390xVersion := map[string]string{
+					"openshift_version": "4.18",
+					"cpu_architecture":  "s390x",
+					"version":           "418.92.202403212258-0",
+					"url":               ts.URL() + "/s390x.iso",
+				}
+
+				// Provide valid ISO response
+				isoContent, isoHeader := isoInfo(validVolumeID)
+				ts.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/s390x.iso"),
+						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
+					),
+				)
+
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{s390xVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Pre-create the cached nmstatectl file to avoid extraction
+				nmstatectlPath, err := is.NmstatectlPathForParams(s390xVersion["openshift_version"], s390xVersion["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.WriteFile(nmstatectlPath, []byte("cached-nmstatectl"), 0755)).To(Succeed()) //nolint:gosec
+
+				// If arch is s390x, CreateMinimalISOTemplate must not be called.
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				// If nmstatectl is cached, BuildNmstateCpioArchive must not be called.
+				mockNmstateHandler.EXPECT().BuildNmstateCpioArchive(gomock.Any()).Times(0)
+				Expect(is.Populate(ctx)).To(Succeed())
+
+			})
+			DescribeTable("happy flow for all architectures  except s390x, with a cached nmstatectl",
+				func(arch string) {
+					archVersion := map[string]string{
+						"openshift_version": "4.18",
+						"cpu_architecture":  arch,
+						"version":           "418.84.202109241901-0",
+						"url":               ts.URL() + "/" + arch + ".iso",
+					}
+
+					// Provide valid ISO response
+					isoContent, isoHeader := isoInfo(validVolumeID)
+					ts.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/"+arch+".iso"),
+							ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
+						),
+					)
+
+					is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{archVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Pre-create nmstatectl cache to avoid actual extraction
+					nmstatectlPath, err := is.NmstatectlPathForParams(archVersion["openshift_version"], archVersion["cpu_architecture"])
+					Expect(err).NotTo(HaveOccurred())
+					cacheContent := fmt.Sprintf("cached-nmstatectl-%s", arch)
+					Expect(os.WriteFile(nmstatectlPath, []byte(cacheContent), 0755)).To(Succeed()) //nolint:gosec
+
+					// Mock minimal ISO creation
+					expectedRootfs := fmt.Sprintf("http://images.example.com/boot-artifacts/rootfs?arch=%s&version=%s", arch, archVersion["openshift_version"])
+					mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), expectedRootfs, arch, gomock.Any(), archVersion["openshift_version"], nmstatectlPath).Return(nil)
+					// If nmstatectl is cached, BuildNmstateCpioArchive must not be called.
+					mockNmstateHandler.EXPECT().BuildNmstateCpioArchive(gomock.Any()).Times(0)
+					Expect(is.Populate(ctx)).To(Succeed())
+				},
+				Entry("x86_64 architecture", "x86_64"),
+				Entry("arm64 architecture", "arm64"),
+				Entry("ppc64le architecture", "ppc64le"),
+			)
+			It("Skip nmstatectl extraction for versions below the minimum supported", func() {
+				oldVersion := map[string]string{
+					"openshift_version": "4.5", // Version that doesn't support nmstatectl
+					"cpu_architecture":  "x86_64",
+					"version":           "45.82.202009222340-0",
+				}
+
+				isoContent, isoHeader := isoInfo(validVolumeID)
+				ts.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/old.iso"),
+						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
+					),
+				)
+				oldVersion["url"] = ts.URL() + "/old.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{oldVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				Expect(err).NotTo(HaveOccurred())
+
+				nmstatectlPath, err := is.NmstatectlPathForParams(oldVersion["openshift_version"], oldVersion["cpu_architecture"])
+				Expect(err).NotTo(HaveOccurred())
+
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), gomock.Any(), "x86_64", gomock.Any(), oldVersion["openshift_version"], nmstatectlPath).Return(nil)
+				mockNmstateHandler.EXPECT().BuildNmstateCpioArchive(gomock.Any()).Times(0)
+
+				Expect(is.Populate(ctx)).To(Succeed())
 			})
 		})
 	})
@@ -530,7 +631,7 @@ var _ = Describe("PathForParams", func() {
 			"url":               "http://example.com/image/x86_64-48.iso",
 			"version":           "48.84.202109241901-0",
 		}}
-		is, err := NewImageStore(nil, "/tmp/some/dir", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
+		is, err := NewImageStore(nil, "/tmp/some/dir", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).NotTo(HaveOccurred())
 		expected := "/tmp/some/dir/rhcos-full-4.8-48.84.202109241901-0-x86_64.iso"
 		Expect(is.PathForParams("full", "4.8", "x86_64")).To(Equal(expected))
@@ -564,7 +665,7 @@ var _ = Describe("HaveVersion", func() {
 
 	BeforeEach(func() {
 		var err error
-		store, err = NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
+		store, err = NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).NotTo(HaveOccurred())
 	})
 	AfterEach(func() {
@@ -595,13 +696,13 @@ var _ = Describe("NewImageStore", func() {
 				"version":           "48.84.202109241901-0",
 			},
 		}
-		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
+		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should error when RHCOS_IMAGES are not set i.e. versions is an empty slice", func() {
 		versions := []map[string]string{}
-		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
+		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("invalid versions: must not be empty"))
 
@@ -615,7 +716,7 @@ var _ = Describe("NewImageStore", func() {
 				"version":          "48.84.202109241901-0",
 			},
 		}
-		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
+		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -627,7 +728,7 @@ var _ = Describe("NewImageStore", func() {
 				"version":           "48.84.202109241901-0",
 			},
 		}
-		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
+		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -639,7 +740,7 @@ var _ = Describe("NewImageStore", func() {
 				"version":           "48.84.202109241901-0",
 			},
 		}
-		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
+		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -651,7 +752,125 @@ var _ = Describe("NewImageStore", func() {
 				"url":               "http://example.com/image/x86_64-48.iso",
 			},
 		}
-		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{})
+		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Context("cleanDataDir", func() {
+	var (
+		dataDir    string
+		ctrl       *gomock.Controller
+		mockEditor *isoeditor.MockEditor
+	)
+
+	BeforeEach(func() {
+		var err error
+		dataDir, err = os.MkdirTemp("", "cleanDataDirTest")
+		Expect(err).NotTo(HaveOccurred())
+
+		ctrl = gomock.NewController(GinkgoT())
+		mockEditor = isoeditor.NewMockEditor(ctrl)
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(dataDir)
+		ctrl.Finish()
+	})
+
+	It("preserves nmstatectl cached files for all architectures", func() {
+		versions := []map[string]string{
+			{
+				"openshift_version": "4.18",
+				"cpu_architecture":  "x86_64",
+				"url":               "http://example.com/image/x86_64-418.iso",
+				"version":           "418.84.202109241901-0",
+			},
+			{
+				"openshift_version": "4.18",
+				"cpu_architecture":  "s390x",
+				"url":               "http://example.com/image/s390x-418.iso",
+				"version":           "418.92.202403212258-0",
+			},
+			{
+				"openshift_version": "4.18",
+				"cpu_architecture":  "arm64",
+				"url":               "http://example.com/image/arm64-418.iso",
+				"version":           "418.84.202109241901-0",
+			},
+			{
+				"openshift_version": "4.18",
+				"cpu_architecture":  "ppc64le",
+				"url":               "http://example.com/image/ppc64le-418.iso",
+				"version":           "418.84.202109241901-0",
+			},
+		}
+
+		is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create expected files
+		fullISOx86 := filepath.Join(dataDir, "rhcos-full-iso-4.18-418.84.202109241901-0-x86_64.iso")
+		fullISOs390x := filepath.Join(dataDir, "rhcos-full-iso-4.18-418.92.202403212258-0-s390x.iso")
+		fullISOarm64 := filepath.Join(dataDir, "rhcos-full-iso-4.18-418.84.202109241901-0-arm64.iso")
+		fullISOppc64le := filepath.Join(dataDir, "rhcos-full-iso-4.18-418.84.202109241901-0-ppc64le.iso")
+		nmstatectlx86 := filepath.Join(dataDir, "nmstatectl-4.18-418.84.202109241901-0-x86_64")
+		nmstatectls390x := filepath.Join(dataDir, "nmstatectl-4.18-418.92.202403212258-0-s390x")
+		nmstatectlarm64 := filepath.Join(dataDir, "nmstatectl-4.18-418.84.202109241901-0-arm64")
+		nmstatectlppc64le := filepath.Join(dataDir, "nmstatectl-4.18-418.84.202109241901-0-ppc64le")
+
+		// Create files that should be kept
+		Expect(os.WriteFile(fullISOx86, []byte("iso-content-x86"), 0600)).To(Succeed())
+		Expect(os.WriteFile(fullISOs390x, []byte("iso-content-s390x"), 0600)).To(Succeed())
+		Expect(os.WriteFile(fullISOarm64, []byte("iso-content-arm64"), 0600)).To(Succeed())
+		Expect(os.WriteFile(fullISOppc64le, []byte("iso-content-ppc64le"), 0600)).To(Succeed())
+		Expect(os.WriteFile(nmstatectlx86, []byte("nmstatectl-x86"), 0755)).To(Succeed())         //nolint:gosec
+		Expect(os.WriteFile(nmstatectls390x, []byte("nmstatectl-s390x"), 0755)).To(Succeed())     //nolint:gosec
+		Expect(os.WriteFile(nmstatectlarm64, []byte("nmstatectl-arm64"), 0755)).To(Succeed())     //nolint:gosec
+		Expect(os.WriteFile(nmstatectlppc64le, []byte("nmstatectl-ppc64le"), 0755)).To(Succeed()) //nolint:gosec
+
+		// Create files that should be removed
+		oldISO := filepath.Join(dataDir, "rhcos-full-iso-4.7-47.84.202109241831-0-x86_64.iso")
+		minimalISO := filepath.Join(dataDir, "rhcos-minimal-iso-4.8-48.84.202109241901-0-x86_64.iso")
+		randomFile := filepath.Join(dataDir, "random-file.txt")
+
+		Expect(os.WriteFile(oldISO, []byte("old-iso"), 0600)).To(Succeed())
+		Expect(os.WriteFile(minimalISO, []byte("minimal-iso"), 0600)).To(Succeed())
+		Expect(os.WriteFile(randomFile, []byte("random"), 0600)).To(Succeed())
+
+		// Clean data directory
+		rhcosStore := is.(*rhcosStore)
+		err = rhcosStore.cleanDataDir()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify expected files still exist
+		_, err = os.Stat(fullISOx86)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(fullISOs390x)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(fullISOarm64)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(fullISOppc64le)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(nmstatectlx86)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(nmstatectls390x)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(nmstatectlarm64)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(nmstatectlppc64le)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify unwanted files were removed
+		_, err = os.Stat(oldISO)
+		Expect(err).To(HaveOccurred())
+		Expect(os.IsNotExist(err)).To(BeTrue())
+		Expect(os.IsNotExist(err)).To(BeTrue())
+		_, err = os.Stat(minimalISO)
+		Expect(err).To(HaveOccurred())
+		Expect(os.IsNotExist(err)).To(BeTrue())
+		_, err = os.Stat(randomFile)
+		Expect(err).To(HaveOccurred())
+		Expect(os.IsNotExist(err)).To(BeTrue())
 	})
 })

--- a/pkg/isoeditor/mock_nmstate_handler.go
+++ b/pkg/isoeditor/mock_nmstate_handler.go
@@ -33,16 +33,17 @@ func (m *MockNmstateHandler) EXPECT() *MockNmstateHandlerMockRecorder {
 	return m.recorder
 }
 
-// CreateNmstateRamDisk mocks base method.
-func (m *MockNmstateHandler) CreateNmstateRamDisk(arg0, arg1, arg2 string) error {
+// BuildNmstateCpioArchive mocks base method.
+func (m *MockNmstateHandler) BuildNmstateCpioArchive(arg0 string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNmstateRamDisk", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "BuildNmstateCpioArchive", arg0)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// CreateNmstateRamDisk indicates an expected call of CreateNmstateRamDisk.
-func (mr *MockNmstateHandlerMockRecorder) CreateNmstateRamDisk(arg0, arg1, arg2 interface{}) *gomock.Call {
+// BuildNmstateCpioArchive indicates an expected call of BuildNmstateCpioArchive.
+func (mr *MockNmstateHandlerMockRecorder) BuildNmstateCpioArchive(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNmstateRamDisk", reflect.TypeOf((*MockNmstateHandler)(nil).CreateNmstateRamDisk), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildNmstateCpioArchive", reflect.TypeOf((*MockNmstateHandler)(nil).BuildNmstateCpioArchive), arg0)
 }

--- a/pkg/isoeditor/nmstate_handler.go
+++ b/pkg/isoeditor/nmstate_handler.go
@@ -15,7 +15,7 @@ import (
 
 //go:generate mockgen -package=isoeditor -destination=mock_nmstate_handler.go . NmstateHandler
 type NmstateHandler interface {
-	CreateNmstateRamDisk(rootfsPath, ramDiskPath, nmstatectlPath string) error
+	BuildNmstateCpioArchive(rootfsPath string) ([]byte, error)
 }
 
 type nmstateHandler struct {
@@ -30,28 +30,7 @@ func NewNmstateHandler(workDir string, executer Executer) NmstateHandler {
 	}
 }
 
-func (n *nmstateHandler) CreateNmstateRamDisk(rootfsPath, ramDiskPath, nmstatectlPath string) error {
-	compressedCpio, err := n.buildNmstateCpioArchive(rootfsPath)
-	if err != nil {
-		return err
-	}
-
-	// write for RAM disk
-	err = os.WriteFile(ramDiskPath, compressedCpio, 0755) //nolint:gosec
-	if err != nil {
-		return err
-	}
-
-	// write for caching
-	err = os.WriteFile(nmstatectlPath, compressedCpio, 0755) //nolint:gosec
-	if err != nil {
-		return err
-	}
-
-	return err
-}
-
-func (n *nmstateHandler) buildNmstateCpioArchive(rootfsPath string) ([]byte, error) {
+func (n *nmstateHandler) BuildNmstateCpioArchive(rootfsPath string) ([]byte, error) {
 	// Extract nmstatectl binary
 	var err error
 	nmstateDir := filepath.Join(n.workDir, "nmstate")

--- a/pkg/isoeditor/nmstate_handler_test.go
+++ b/pkg/isoeditor/nmstate_handler_test.go
@@ -1,6 +1,7 @@
 package isoeditor
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -32,51 +33,116 @@ var _ = Context("with test files", func() {
 		Expect(os.RemoveAll(workDir)).To(Succeed())
 	})
 
-	Describe("CreateNmstateRamDisk", func() {
+	Describe("BuildNmstateCpioArchive", func() {
 		var (
-			extractDir, ramDiskPath, nmstatectlPath, nmstatectlPathForCaching string
-			err                                                               error
-			nmstateHandler                                                    NmstateHandler
-			ctrl                                                              *gomock.Controller
-			mockExecuter                                                      *MockExecuter
+			rootfsPath        string
+			newNmstateHandler NmstateHandler
+			ctrl              *gomock.Controller
+			mockExecuter      *MockExecuter
 		)
 
 		BeforeEach(func() {
-			extractDir = os.TempDir()
+			rootfsPath = filepath.Join(workDir, "rootfs.img")
 
-			nmstateDir := filepath.Join(extractDir, "nmstate", "squashfs-root")
-			err = os.MkdirAll(nmstateDir, os.ModePerm)
-			Expect(err).ToNot(HaveOccurred())
-
-			nmstatectlPath = filepath.Join(nmstateDir, "nmstatectl")
-			_, err := os.Create(nmstatectlPath)
-			Expect(err).ToNot(HaveOccurred())
-
-			ramDisk, err := os.CreateTemp(extractDir, "nmstate.img")
-			Expect(err).ToNot(HaveOccurred())
-
-			nmstatectlPathForCaching = filepath.Join(workDir, "nmstatectl-openshiftVersion-version-arch")
-
-			ramDiskPath = ramDisk.Name()
+			// Create a dummy rootfs file
+			err := os.WriteFile(rootfsPath, []byte("dummy-rootfs"), 0644) //nolint:gosec
+			Expect(err).NotTo(HaveOccurred())
 
 			ctrl = gomock.NewController(GinkgoT())
 			mockExecuter = NewMockExecuter(ctrl)
-			mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("nmstatectl", nil).Times(3)
-			nmstateHandler = NewNmstateHandler(os.TempDir(), mockExecuter)
 		})
 
 		AfterEach(func() {
-			os.Remove(extractDir)
-			os.Remove(ramDiskPath)
+			ctrl.Finish()
+		})
+		It("builds nmstate cpio archive", func() {
+			// Mock the execution sequence for successful extraction
+			gomock.InOrder(
+				// First call: extract rootfs with cpio
+				mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("", nil),
+				// Second call: list squashfs contents to find nmstatectl
+				mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("/ostree/deploy/rhcos/deploy/abc123/usr/bin/nmstatectl", nil),
+				// Third call: extract the nmstatectl binary
+				mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("", nil),
+			)
+
+			// Create the expected directory structure and nmstatectl binary
+			extractDir := filepath.Join(workDir, "nmstate")
+			squashfsRoot := filepath.Join(extractDir, "squashfs-root")
+			nmstatectlDir := filepath.Join(squashfsRoot, "ostree", "deploy", "rhcos", "deploy", "abc123", "usr", "bin")
+			err := os.MkdirAll(nmstatectlDir, os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
+			nmstatectlBinary := filepath.Join(nmstatectlDir, "nmstatectl")
+			nmstatectlContent := []byte("mock-nmstatectl-binary")
+			err = os.WriteFile(nmstatectlBinary, nmstatectlContent, 0755) //nolint:gosec
+			Expect(err).NotTo(HaveOccurred())
+
+			newNmstateHandler = NewNmstateHandler(workDir, mockExecuter)
+
+			compressedCpio, err := newNmstateHandler.BuildNmstateCpioArchive(rootfsPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(compressedCpio).NotTo(BeEmpty())
 		})
 
-		It("ram disk created successfully", func() {
-			err := nmstateHandler.CreateNmstateRamDisk("", ramDiskPath, nmstatectlPathForCaching)
-			Expect(err).ToNot(HaveOccurred())
+		It("handles cpio extraction failure", func() {
+			// Mock cpio extraction failure
+			mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("", fmt.Errorf("cpio extraction failed"))
 
-			exists, err := fileExists(ramDiskPath)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(exists).To(BeTrue())
+			newNmstateHandler = NewNmstateHandler(workDir, mockExecuter)
+
+			_, err := newNmstateHandler.BuildNmstateCpioArchive(rootfsPath)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cpio extraction failed"))
+		})
+
+		It("handles squashfs listing failure", func() {
+			gomock.InOrder(
+				// First call succeeds (cpio extraction)
+				mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("", nil),
+				// Second call fails (squashfs listing)
+				mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("", fmt.Errorf("squashfs listing failed")),
+			)
+
+			newNmstateHandler = NewNmstateHandler(workDir, mockExecuter)
+
+			_, err := newNmstateHandler.BuildNmstateCpioArchive(rootfsPath)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("squashfs listing failed"))
+		})
+
+		It("handles nmstatectl binary not found", func() {
+			gomock.InOrder(
+				// First call succeeds (cpio extraction)
+				mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("", nil),
+				// Second call succeeds but doesn't return nmstatectl path
+				mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("/some/other/binary", nil),
+				// Third call should still be made with empty binary path
+				mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("", nil),
+			)
+
+			newNmstateHandler = NewNmstateHandler(workDir, mockExecuter)
+
+			_, err := newNmstateHandler.BuildNmstateCpioArchive(rootfsPath)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no such file or directory"))
+		})
+
+		It("handles squashfs extraction failure", func() {
+			gomock.InOrder(
+				// First call succeeds (cpio extraction)
+				mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("", nil),
+				// Second call succeeds (squashfs listing)
+				mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("/ostree/deploy/rhcos/deploy/abc123/usr/bin/nmstatectl", nil),
+				// Third call fails (squashfs extraction)
+				mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("", fmt.Errorf("squashfs extraction failed")),
+			)
+
+			newNmstateHandler = NewNmstateHandler(workDir, mockExecuter)
+
+			_, err := newNmstateHandler.BuildNmstateCpioArchive(rootfsPath)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("squashfs extraction failed"))
 		})
 	})
 })

--- a/pkg/isoeditor/rhcos_test.go
+++ b/pkg/isoeditor/rhcos_test.go
@@ -56,7 +56,6 @@ var _ = Context("with test files", func() {
 		mockNmstateHandler = NewMockNmstateHandler(ctrl)
 		mockExecuter = NewMockExecuter(ctrl)
 		mockExecuter.EXPECT().Execute(gomock.Any(), gomock.Any()).Return("some string", nil).Times(3)
-		mockNmstateHandler.EXPECT().CreateNmstateRamDisk(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Due to [this]( https://github.com/openshift/assisted-image-service/blob/1b29aba9d5bee83a536e40233a8170dbb2c72520/pkg/imagestore/imagestore.go#L286-L290) condition, the nmstatectl binary is never fetched for the s390x architecture.

This fix addresses the issue by decoupling the extraction of nmstatectl from the minimal ISO flow - since minimal ISO is not supported for s390x. Instead, the binary is now cached, ensuring it is available for s390x as well.

Assisted-by: Cursor

## How was this code tested?
Test 1:
1. Created a cluster with the s390x architecture and static network configuration.
2. Downloaded the PXE boot script.
3. Retrieved the initrd image referenced in the script.
4. Verified that nmstatectl is included in the image using binwalk.

Test 2:
1. Created a cluster with the s390x architecture and static network configuration.
2. Downloaded the PXE boot script.
3. Retrieved the initrd, kernel and kernel args
4. Launch a VM on a Beaker s390x machine and boot it using the artifacts.
5. Confirm that the VM boots successfully and is discovered as expected.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @jhernand 
/cc @danielerez 

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [X] Title and description added to both, commit and PR
- [X] Relevant issues have been associated
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
