### PR TITLE
OCPBUGS-37943: FIPS based ISO Boot support for s390x arch

### DIFF
--- a/pkg/isoeditor/kargs_test.go
+++ b/pkg/isoeditor/kargs_test.go
@@ -2,6 +2,8 @@ package isoeditor
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -151,5 +153,141 @@ menuentry 'Fedora CoreOS (Live)' --class fedora --class gnu-linux --class gnu --
 			Expect(start).To(Equal(int64(1375)))
 			Expect(length).To(Equal(int64(1024)))
 		})
+	})
+})
+
+// Tests for EmbedKargsIntoBootImage
+var _ = Describe("EmbedKargsIntoBootImage", func() {
+	var (
+		baseDir    string // acts as baseIsoPath (where /coreos/kargs.json is read from)
+		stagingDir string // acts as stagingIsoPath (where files are written)
+	)
+
+	writeBaseKargsJSON := func(json string) {
+		p := filepath.Join(baseDir, "coreos", "kargs.json")
+		Expect(os.MkdirAll(filepath.Dir(p), 0755)).To(Succeed())
+		Expect(os.WriteFile(p, []byte(json), 0644)).To(Succeed())
+	}
+
+	// helper to create a target file inside staging dir with a given size (filled with zeros)
+	createStagingFile := func(rel string, size int) string {
+		full := filepath.Join(stagingDir, rel)
+		Expect(os.MkdirAll(filepath.Dir(full), 0755)).To(Succeed())
+		buf := make([]byte, size)
+		Expect(os.WriteFile(full, buf, 0644)).To(Succeed())
+		return full
+	}
+
+	BeforeEach(func() {
+		var err error
+		baseDir, err = os.MkdirTemp("", "iso-base")
+		Expect(err).ToNot(HaveOccurred())
+		stagingDir, err = os.MkdirTemp("", "iso-staging")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(baseDir)
+		os.RemoveAll(stagingDir)
+	})
+
+	It("fails when /coreos/kargs.json cannot be read from base ISO path", func() {
+		// Do NOT create base coreos/kargs.json
+		err := EmbedKargsIntoBootImage(baseDir, stagingDir, "any")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to read kargs config"))
+	})
+
+	It("fails when /coreos/kargs.json is malformed", func() {
+		writeBaseKargsJSON(`{ not valid json }`)
+		err := EmbedKargsIntoBootImage(baseDir, stagingDir, "newKargs")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to parse"))
+	})
+
+	It("fails when no kargs file entries are present", func() {
+		writeBaseKargsJSON(`{"default":"abc","files":[],"size":10}`)
+		err := EmbedKargsIntoBootImage(baseDir, stagingDir, "extra")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no kargs file entries"))
+	})
+
+	It("fails when a listed staging file does not exist", func() {
+		writeBaseKargsJSON(`{
+			"default": "abc",
+			"files": [{"path":"cdboot.img","offset":10}],
+			"size": 100
+		}`)
+		// Don't create cdboot.img in staging
+		err := EmbedKargsIntoBootImage(baseDir, stagingDir, "zzz")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("does not exist"))
+	})
+
+	It("fails when kargs length exceeds configured Size", func() {
+		// default=3 chars, custom=9 chars -> total 12 > size 10
+		writeBaseKargsJSON(`{
+			"default": "abc",
+			"files": [{"path":"cdboot.img","offset":0}],
+			"size": 10
+		}`)
+		_ = createStagingFile("cdboot.img", 32)
+		err := EmbedKargsIntoBootImage(baseDir, stagingDir, "toolonggg")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("exceeds available field size"))
+	})
+
+	It("fails when size is not provided but available space (by file length) is insufficient", func() {
+		// Size=0 means use file size heuristic:
+		// file size 8, offset=4, default len=3 -> append offset = 7, remaining = 1
+		// total needed default+custom = 3 + 3 = 6 > 1 -> error
+		writeBaseKargsJSON(`{
+			"default": "abc",
+			"files": [{"path":"cdboot.img","offset":4}],
+			"size": 0
+		}`)
+		_ = createStagingFile("cdboot.img", 8)
+		err := EmbedKargsIntoBootImage(baseDir, stagingDir, "xyz")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("exceeds available field size"))
+	})
+
+	It("fails when the staging path exists but is a directory (open for write fails)", func() {
+		writeBaseKargsJSON(`{
+			"default": "abc",
+			"files": [{"path":"cdboot.img","offset":5}],
+			"size": 100
+		}`)
+		// Create a directory named cdboot.img
+		Expect(os.MkdirAll(filepath.Join(stagingDir, "cdboot.img"), 0755)).To(Succeed())
+		err := EmbedKargsIntoBootImage(baseDir, stagingDir, "ok")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to open target file"))
+	})
+
+	It("successfully embeds kargs into TWO different files with different offsets", func() {
+		// default is "abc" (len=3)
+		writeBaseKargsJSON(`{
+			"default": "abc",
+			"files": [
+				{"path":"cdboot.img","offset":10},
+				{"path":"coreos/kargs.json","offset":20}
+			],
+			"size": 1024
+		}`)
+		cdboot := createStagingFile("cdboot.img", 256)
+		kargsBin := createStagingFile("coreos/kargs.json", 256)
+
+		custom := "dual-file=ok"
+		Expect(EmbedKargsIntoBootImage(baseDir, stagingDir, custom)).To(Succeed())
+
+		// Verify writes at offset + len(default)
+		cd, err := os.ReadFile(cdboot)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(cd[10+3 : 10+3+len(custom)])).To(Equal(custom))
+
+		kb, err := os.ReadFile(kargsBin)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(kb[20+3 : 20+3+len(custom)])).To(Equal(custom))
 	})
 })


### PR DESCRIPTION
## Description

### Summary
This PR introduces enhancements to the `kargs.go` file, particularly focusing on appending kargs into the boot image itself where ignition is already embedded using the staging ISO boot image files. This is necessary for architecture like s390x where ignition and kargs lies in the same boot image (`cdboot.img`) unlike x86 where we have different boot files for booth. 

It includes a newly added function for embedding kernel arguments into boot images `EmbedKargsIntoBootImage`, plus unit tests for the same to ensure reliability and correctness.

### Key Enhancements

#### EmbedKargsIntoBootImage Function

**Purpose:** 

- Allows embedding additional kernel arguments (kargs) into boot images where ignition is also present in the same at a different offset.
- Fetches the kargs details such as default kargs, kargs size and offset from `coreos/kargs.jso` instead of calculating it based on the marker `COREOS_KARGS_EMBED_AREA` which is not present in s390x ISO boot files


**Benefit:** Enhances flexibility and control over boot-time configurations—crucial for architectures needing to embed the kernel parameters into ignition boot images (e.g., s390x).

**Rationale:** This is created as a public function to make sure it can be accessed from the installer repo to have decision making in the `appendKargs` function to call this function instead NewKargsReader function, which relies on several factors which are not relevant for s390x and also archs having to embed kargs into same boot image as ignition content.

## How was this code tested?

### Unit Tests for EmbedKargsIntoBootImage

The tests simulate real ISO staging scenarios by creating temporary base and staging directories, then exercising both failure cases and success cases.

**Failure Scenarios Covered:**

- Missing config file: Fails when /coreos/kargs.json cannot be read from the base ISO path.
- Malformed JSON: Fails when kargs.json contains invalid JSON.
- Empty entries: Fails when no files entries are present in kargs.json.
- Missing staging files: Fails if a listed target file does not exist in the staging directory.
- Field size exceeded (explicit size): Errors if combined default + custom kernel args exceed the configured size field.
- Field size exceeded (inferred size): Errors if size=0 but the available file space (based on length/offset) is insufficient.
- Invalid target file: Errors if the target path exists but is not a writable file (e.g., a directory).

**Success Scenario:**

- Multiple files with offsets: Verifies that custom kernel arguments are correctly embedded into two different files at different offsets, appended immediately after the default arguments.


### Functional tests

- Successfully generated Agent ISO image with `fips: true` having s390x arch
- Successfully created an SNO cluster with the same ISO image where FIPS is enabled after boot
- Performed the same for `fips: false` as well

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @zaneb 
/cc @andfasano 

## Links 

- This PR works in favour of s390x arch which gets consumed by `appendKargs` function in a decision making in the `installer` codebase. 
- Check out this PR: https://github.com/openshift/installer/pull/9892
- Corresponding slack discussion : https://redhat-internal.slack.com/archives/C06A57N4WEM/p1745332383117689

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)
