### PR TITLE
MGMT-21574: Allow `rhel-coreos-` as a valid volume ID prefix

### DIFF
--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -231,11 +231,21 @@ func validateISOID(path string) error {
 		return err
 	}
 
-	if !strings.HasPrefix(volumeID, "rhcos-") && !strings.HasPrefix(volumeID, "fedora-coreos-") && !strings.HasPrefix(volumeID, "scos-") {
+	if !isoIDHasValidPrefix(volumeID) {
 		return fmt.Errorf("ISO volume identifier (%s) is invalid", volumeID)
 	}
 
 	return nil
+}
+
+func isoIDHasValidPrefix(volumeID string) bool {
+	validPrefixes := []string{"rhcos-", "rhel-coreos-", "fedora-coreos-", "scos-"}
+	for _, prefix := range validPrefixes {
+		if strings.HasPrefix(volumeID, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *rhcosStore) Populate(ctx context.Context) error {


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

RHCOS 9.6/10.1 ISOs will soon have that volume ID there. The change was done thinking it was low risk since it's mostly cosmetic but it turns out we check for this here.

We could revert it, but... hopefully this patch is enough to fix things.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

`make`

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 

## Links
<!--
List any applicable links to related PRs or issues
-->

- https://github.com/osbuild/osbuild/pull/2148
- https://redhat-internal.slack.com/archives/C999USB0D/p1755549666133839?thread_ts=1755284973.982289&cid=C999USB0D

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
