### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for assisted-image-service-acm-ds-2-14

### DIFF
--- a/Dockerfile.image-service-mce
+++ b/Dockerfile.image-service-mce
@@ -91,4 +91,5 @@ LABEL com.redhat.component="multicluster-engine-assisted-image-service-container
       io.openshift.tags="OpenShift 4" \
       upstream_commit="${version}" \
       org.label-schema.vcs-ref="${version}" \
-      org.label-schema.vcs-url="https://github.com/openshift/assisted-image-service"
+      org.label-schema.vcs-url="https://github.com/openshift/assisted-image-service" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
