### PR TITLE
[release-ocm-2.10] - NO_ISSUE: CVE-2025-47907 Upgrade golang to 1.24.6

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.24-openshift-4.21

--- a/Dockerfile.image-service
+++ b/Dockerfile.image-service
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
 USER 0
 

--- a/Dockerfile.image-service-build
+++ b/Dockerfile.image-service-build
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
 ENV GOFLAGS=""
 


### PR DESCRIPTION
## Summary
Upgrade golang to 1.24.6 and golangci-lint to 1.64.8 to address CVE-2025-47907.

## Changes
- Updated golang version to 1.24.6
- Updated golangci-lint version to 1.64.8
- Added toolchain directive for consistent builds