### PR TITLE
MGMT-21723: Update Renovate for legacy EL8 Dockerfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,17 @@
             ],
             "depNameTemplate": "registry.access.redhat.com/ubi9/go-toolset",
             "datasourceTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^Dockerfile.image-service-mce$"
+            ],
+            "matchStrings": [
+                "FROM --platform=\\$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:(?<currentValue>.*?) AS builder\\n"
+            ],
+            "depNameTemplate": "registry.access.redhat.com/ubi8/go-toolset",
+            "datasourceTemplate": "docker"
         }
     ],
 
@@ -50,13 +61,19 @@
             "groupName": "Go Builder",
             "addLabels": ["golang"],
             "matchDatasources": ["docker"],
-            "matchPackageNames": ["registry.access.redhat.com/ubi9/go-toolset"],
+            "matchPackageNames": [
+                "registry.access.redhat.com/ubi8/go-toolset",
+                "registry.access.redhat.com/ubi9/go-toolset"
+            ],
             "allowedVersions": "/^[0-9]+\\.[0-9]+$/"
         },
         {
             "matchUpdateTypes": ["major"],
             "matchDatasources": ["docker"],
-            "matchPackageNames": ["registry.access.redhat.com/ubi9/go-toolset"],
+            "matchPackageNames": [
+                "registry.access.redhat.com/ubi8/go-toolset",
+                "registry.access.redhat.com/ubi9/go-toolset"
+            ],
             "enabled": false
         },
         {


### PR DESCRIPTION
Adds a custom regex manager targeting registry.access.redhat.com/ubi8/go-toolset in Dockerfile.image-service-mce so that the release-ocm-2.11 branch also receives automatic go-toolset bumps.

## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->
Adds a custom regex manager targeting registry.access.redhat.com/ubi8/go-toolset in Dockerfile.image-service-mce so that the release-ocm-2.11 branch also receives automatic go-toolset bumps.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)
