### PR TITLE
AGENT-1497: Rename OVE ISO download filename to agent-ove.<arch>.iso

### DIFF
--- a/internal/handlers/iso.go
+++ b/internal/handlers/iso.go
@@ -84,6 +84,9 @@ func (h *isoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer isoReader.Close()
 
 	fileName := fmt.Sprintf("%s-discovery.iso", params.imageID)
+	if params.imageType == imagestore.ImageTypeDisconnectedIso {
+		fileName = fmt.Sprintf("agent-ove.%s.iso", params.arch)
+	}
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fileName))
 	modTime, err := http.ParseTime(lastModified)
 	if err != nil {

--- a/internal/handlers/iso_test.go
+++ b/internal/handlers/iso_test.go
@@ -209,6 +209,18 @@ var _ = Describe("ServeHTTP", func() {
 					expectSuccessfulResponse(resp, []byte("someisocontent"))
 				})
 
+				It("returns a disconnected image with agent-ove filename", func() {
+					initIgnitionHandler("discovery_iso_type=disconnected-iso&file_name=discovery.ign")
+					mockImageStore.EXPECT().HaveVersion("4.8", defaultArch).Return(true)
+					mockImageStore.EXPECT().PathForParams(imagestore.ImageTypeDisconnectedIso, "4.8", defaultArch).Return(fullImageFilename)
+					path := fmt.Sprintf("/byid/%s/4.8/x86_64/disconnected.iso", imageID)
+					setInfraenvKargsHandlerSuccess()
+					resp, err := client.Get(server.URL + path)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(resp.StatusCode).To(Equal(http.StatusOK))
+					Expect(resp.Header.Get("Content-Disposition")).To(Equal("attachment; filename=agent-ove.x86_64.iso"))
+				})
+
 				It("returns a minimal image with an initrd", func() {
 					initIgnitionHandler("discovery_iso_type=minimal-iso&file_name=discovery.ign")
 					initrdContent = []byte("someramdisk")


### PR DESCRIPTION
## Summary
- OVE/disconnected ISOs were downloaded as `<cluster_id>-discovery.iso`, which is confusing for users
- Renamed to `agent-ove.<arch>.iso` (e.g., `agent-ove.x86_64.iso`) for the disconnected-iso type only
- Regular full/minimal ISOs retain existing `<id>-discovery.iso` naming

## Test plan
- [x] Unit test added verifying `Content-Disposition` header contains `agent-ove.x86_64.iso` for disconnected-iso type
- [x] All existing handler tests pass (91/91)
- [ ] Verify OVE ISO download in SaaS UI names file correctly

Jira: https://issues.redhat.com/browse/AGENT-1497