### PR TITLE
NO-ISSUE: Bump linter

### DIFF
--- a/Dockerfile.image-service-build
+++ b/Dockerfile.image-service-build
@@ -2,7 +2,9 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS golang
 
 ENV GOFLAGS=""
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.0 && \
+ARG GOLANGCI_LINT_VERSION=v2.12.2
+
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCI_LINT_VERSION}/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION} && \
     go install golang.org/x/tools/cmd/goimports@v0.34.0 && \
     go install go.uber.org/mock/mockgen@v0.6.0
 

--- a/internal/handlers/boot_artifacts.go
+++ b/internal/handlers/boot_artifacts.go
@@ -88,7 +88,9 @@ func (b *BootArtifactsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 	defer fileReader.Close()
 
-	fileInfo, err := os.Stat(isoFileName)
+	// isoFileName is safe: version and arch are validated against a known whitelist by HaveVersion()
+	// before reaching this point, so path traversal via user input is not possible.
+	fileInfo, err := os.Stat(isoFileName) //nolint:gosec // G703 false positive, path is whitelisted
 	if err != nil {
 		httpErrorf(w, http.StatusInternalServerError, "Error reading file info for %s", isoFileName)
 		return

--- a/internal/handlers/initrd.go
+++ b/internal/handlers/initrd.go
@@ -102,7 +102,7 @@ func initrdOverlayReader(imageStore imagestore.ImageStore, client *AssistedServi
 			if err != nil {
 				return nil, "", http.StatusInternalServerError, err
 			}
-			nmstateImgContent, err := os.Open(nmstatectlPath)
+			nmstateImgContent, err := os.Open(nmstatectlPath) //nolint:gosec // G703 false positive, path is checked inside NmstatectlPathForParams
 			if err != nil {
 				return nil, "", http.StatusInternalServerError, fmt.Errorf("failed to read nmstate img: %v", err)
 			}

--- a/pkg/isoeditor/rhcos.go
+++ b/pkg/isoeditor/rhcos.go
@@ -220,7 +220,8 @@ func fixGrubConfig(rootFSURL, extractDir string, includeNmstateRamDisk bool, kar
 	}
 
 	// Write the modified content back to the file
-	return os.WriteFile(foundGrubPath, []byte(contentStr), 0600)
+	// foundGrubPath is safe: built from extractDir (os.MkdirTemp output) and a hardcoded path list.
+	return os.WriteFile(foundGrubPath, []byte(contentStr), 0600) //nolint:gosec // G703 false positive, path is application-controlled
 }
 
 // fixIsolinuxConfig modifies isolinux.cfg and updates kargs config in place
@@ -261,7 +262,8 @@ func fixIsolinuxConfig(rootFSURL, extractDir string, includeNmstateRamDisk bool,
 	}
 
 	// Write the modified content back to the file
-	return os.WriteFile(isolinuxPath, []byte(contentStr), 0600)
+	// isolinuxPath is safe: built from extractDir (os.MkdirTemp output) and a hardcoded constant.
+	return os.WriteFile(isolinuxPath, []byte(contentStr), 0600) //nolint:gosec // G703 false positive, path is application-controlled
 }
 
 // editString applies a regex replacement to a string and returns the modified string

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
                 "/^Dockerfile.image-service-build$/"
             ],
             "matchStrings": [
-                "RUN curl .*https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- .* (?<currentValue>.*?) && .*"
+                "ARG GOLANGCI_LINT_VERSION=(?<currentValue>[^\\s]+)\\n"
             ],
             "depNameTemplate": "github.com/golangci/golangci-lint",
             "datasourceTemplate": "go"


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the Go linting tool version used during image builds for more predictable builds.
  * Updated dependency version tracking so automated updates read the pinned build argument correctly.

* **Bug Fixes**
  * Added safety notes and lint suppressions for file-access paths where validation already ensures the inputs are safe.
  * Kept ISO and boot artifact processing behavior unchanged while reducing false security warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->