### PR TITLE
MGMT-24783: Allow getting OS Images by RHCOS version

### DIFF
--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -14,12 +14,13 @@ import (
 	"strings"
 
 	"github.com/google/renameio"
-	"github.com/openshift/assisted-image-service/internal/common"
-	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/openshift/assisted-image-service/internal/common"
+	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 )
 
 var DefaultVersions = []map[string]string{
@@ -279,12 +280,12 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 		return err
 	}
 
+	versions := deduplicateVersions(s.versions)
 	errs, _ := errgroup.WithContext(ctx)
 
-	for i := range s.versions {
-		imageInfo := s.versions[i]
+	for i := range versions {
+		imageInfo := versions[i]
 		errs.Go(func() error {
-			openshiftVersion := imageInfo["openshift_version"]
 			imageVersion := imageInfo["version"]
 			arch := imageInfo["cpu_architecture"]
 
@@ -293,7 +294,7 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 				return fmt.Errorf("failed to get image type: %v", err)
 			}
 
-			fullPath := filepath.Join(s.dataDir, isoFileName(imageType, openshiftVersion, imageVersion, arch))
+			fullPath := filepath.Join(s.dataDir, isoFileName(imageType, imageVersion, arch))
 			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
 				url := imageInfo["url"]
 				log.Infof("Downloading iso from %s to %s", url, fullPath)
@@ -302,7 +303,7 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 				if err != nil {
 					return fmt.Errorf("failed to download %s: %v", url, err)
 				}
-				log.Infof("Finished downloading for %s-%s (%s)", openshiftVersion, arch, imageVersion)
+				log.Infof("Finished downloading for %s-%s", imageVersion, arch)
 				if err := validateISOID(fullPath); err != nil {
 					message := fmt.Sprintf("failed to validate %s: %v", fullPath, err)
 					if err = os.Remove(fullPath); err != nil {
@@ -333,8 +334,8 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 		return err
 	}
 
-	for i := range s.versions {
-		imageInfo := s.versions[i]
+	for i := range versions {
+		imageInfo := versions[i]
 		openshiftVersion := imageInfo["openshift_version"]
 		imageVersion := imageInfo["version"]
 		arch := imageInfo["cpu_architecture"]
@@ -350,8 +351,8 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 		}
 
 		// Extract and cache nmstatectl for all architectures
-		if err := s.extractAndCacheNmstatectl(openshiftVersion, arch); err != nil {
-			return fmt.Errorf("failed to extract and cache nmstatectl for %s-%s: %v", openshiftVersion, arch, err)
+		if err := s.extractAndCacheNmstatectl(imageInfo); err != nil {
+			return fmt.Errorf("failed to extract and cache nmstatectl for %s-%s: %v", imageVersion, arch, err)
 		}
 
 		// Don't attempt to create a minimal ISO for s390x because there's no easy way to edit the kernel parameters
@@ -359,17 +360,17 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 		if arch == "s390x" {
 			continue
 		}
-		minimalPath := filepath.Join(s.dataDir, isoFileName(ImageTypeMinimal, openshiftVersion, imageVersion, arch))
+		minimalPath := filepath.Join(s.dataDir, isoFileName(ImageTypeMinimal, imageVersion, arch))
 		if _, err := os.Stat(minimalPath); os.IsNotExist(err) {
-			log.Infof("Creating minimal iso for %s-%s-%s", openshiftVersion, imageVersion, arch)
+			log.Infof("Creating minimal iso for %s-%s", imageVersion, arch)
 
-			fullPath := filepath.Join(s.dataDir, isoFileName(ImageTypeFull, openshiftVersion, imageVersion, arch))
-			rootfsURL, err := buildRootfsURL(s.imageServiceBaseURL, arch, openshiftVersion)
+			fullPath := filepath.Join(s.dataDir, isoFileName(ImageTypeFull, imageVersion, arch))
+			rootfsURL, err := buildRootfsURL(s.imageServiceBaseURL, arch, imageVersion)
 			if err != nil {
 				return fmt.Errorf("failed to build rootfs URL: %v", err)
 			}
 
-			nmstatectlPath, err := s.NmstatectlPathForParams(openshiftVersion, arch)
+			nmstatectlPath, err := s.NmstatectlPathForParams(imageVersion, arch)
 			if err != nil {
 				return err
 			}
@@ -378,11 +379,53 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 				return fmt.Errorf("failed to create minimal iso template for version %s: %v", imageInfo, err)
 			}
 
-			log.Infof("Finished creating minimal iso for %s-%s (%s)", openshiftVersion, arch, imageVersion)
+			log.Infof("Finished creating minimal iso for %s-%s", imageVersion, arch)
 		}
 	}
 
 	return nil
+}
+
+// deduplicateVersions keeps a single entry per RHCOS version and CPU architecture pair.
+// When multiple pairs share the same RHCOS image, the entry with the highest openshift_version is kept.
+// It's important to keep that entry because the openshift_version is used to decide if we want the nmstatectl for that entry.
+func deduplicateVersions(versions []map[string]string) []map[string]string {
+	m := make(map[string]map[string]string, len(versions))
+
+	for _, entry := range versions {
+		key := entry["version"] + "@" + entry["cpu_architecture"]
+		existing, ok := m[key]
+		if !ok {
+			m[key] = entry
+			continue
+		}
+		greater, err := common.VersionGreaterOrEqual(entry["openshift_version"], existing["openshift_version"])
+		if err != nil {
+			log.Debugf(
+				"Couldn't check if OS image entry for RHCOS version %s and architecture %s with openshift_version %s has a greater openshift version, keeping %s, error: %v",
+				entry["version"], entry["cpu_architecture"], entry["openshift_version"], existing["openshift_version"], err,
+			)
+			continue
+		}
+		if greater {
+			log.Debugf(
+				"Replacing duplicate OS image entry for RHCOS version %s and architecture %s with openshift_version %s (was %s)",
+				entry["version"], entry["cpu_architecture"], entry["openshift_version"], existing["openshift_version"],
+			)
+			m[key] = entry
+		} else {
+			log.Debugf(
+				"Skipping duplicate OS image entry for RHCOS version %s and architecture %s (openshift_version %s, keeping %s)",
+				entry["version"], entry["cpu_architecture"], entry["openshift_version"], existing["openshift_version"],
+			)
+		}
+	}
+
+	result := make([]map[string]string, 0, len(m))
+	for _, entry := range m {
+		result = append(result, entry)
+	}
+	return result
 }
 
 func (*rhcosStore) getImageType(imageInfo map[string]string) (string, error) {
@@ -405,32 +448,36 @@ func (*rhcosStore) getImageType(imageInfo map[string]string) (string, error) {
 
 // extractAndCacheNmstatectl extracts nmstatectl from the rootfs and caches it for later use
 // This ensures nmstatectl is available for both minimal ISO creation and PXE provisioning
-func (s *rhcosStore) extractAndCacheNmstatectl(openshiftVersion, arch string) error {
+func (s *rhcosStore) extractAndCacheNmstatectl(imageInfo map[string]string) error {
+	openshiftVersion := imageInfo["openshift_version"]
+	imageVersion := imageInfo["version"]
+	arch := imageInfo["cpu_architecture"]
+
 	// Check if version supports nmstatectl
 	versionOK, err := common.VersionGreaterOrEqual(openshiftVersion, isoeditor.MinimalVersionForNmstatectl)
 	if err != nil {
 		return err
 	}
 	if !versionOK {
-		log.Debugf("Skipping nmstatectl extraction for %s-%s (version does not support nmstatectl)", openshiftVersion, arch)
+		log.Debugf("Skipping nmstatectl extraction for %s-%s (version does not support nmstatectl)", imageVersion, arch)
 		return nil
 	}
 
-	nmstatectlPath, err := s.NmstatectlPathForParams(openshiftVersion, arch)
+	nmstatectlPath, err := s.NmstatectlPathForParams(imageVersion, arch)
 	if err != nil {
 		return err
 	}
 
 	// Check if nmstatectl is already cached
 	if _, err = os.Stat(nmstatectlPath); err == nil {
-		log.Debugf("nmstatectl already cached for %s-%s", openshiftVersion, arch)
+		log.Debugf("nmstatectl already cached for %s-%s", imageVersion, arch)
 		return nil
 	}
 
-	log.Infof("Extracting and caching nmstatectl for %s-%s", openshiftVersion, arch)
+	log.Infof("Extracting and caching nmstatectl for %s-%s", imageVersion, arch)
 
 	// Get the path to the full ISO
-	fullPath := s.PathForParams(ImageTypeFull, openshiftVersion, arch)
+	fullPath := s.PathForParams(ImageTypeFull, imageVersion, arch)
 
 	// Read rootfs directly from ISO
 	rootfsFile, err := isoeditor.GetFileFromISO(fullPath, isoeditor.RootfsImagePath)
@@ -475,22 +522,41 @@ func (s *rhcosStore) extractAndCacheNmstatectl(openshiftVersion, arch string) er
 		return fmt.Errorf("failed to cache nmstatectl: %v", err)
 	}
 
-	log.Infof("Successfully cached nmstatectl for %s-%s", openshiftVersion, arch)
+	log.Infof("Successfully cached nmstatectl for %s-%s", imageVersion, arch)
 	return nil
 }
 
-func (s *rhcosStore) PathForParams(imageType, openshiftVersion, arch string) string {
-	var version string
+func (s *rhcosStore) findVersionEntry(versionKey, arch string) map[string]string {
 	for _, entry := range s.versions {
-		if entry["openshift_version"] == openshiftVersion && entry["cpu_architecture"] == arch {
-			version = entry["version"]
+		if entry["cpu_architecture"] != arch {
+			continue
+		}
+		if entry["version"] == versionKey {
+			return entry
 		}
 	}
-	return filepath.Join(s.dataDir, isoFileName(imageType, openshiftVersion, version, arch))
+	for _, entry := range s.versions {
+		if entry["cpu_architecture"] != arch {
+			continue
+		}
+		if entry["openshift_version"] == versionKey {
+			return entry
+		}
+	}
+	return nil
 }
 
-func isoFileName(imageType, openshiftVersion, version, arch string) string {
-	return fmt.Sprintf("rhcos-%s-%s-%s-%s.iso", imageType, openshiftVersion, version, arch)
+func (s *rhcosStore) PathForParams(imageType, versionKey, arch string) string {
+	rhcosVersion := versionKey
+	entry := s.findVersionEntry(versionKey, arch)
+	if entry != nil {
+		rhcosVersion = entry["version"]
+	}
+	return filepath.Join(s.dataDir, isoFileName(imageType, rhcosVersion, arch))
+}
+
+func isoFileName(imageType, version, arch string) string {
+	return fmt.Sprintf("rhcos-%s-%s-%s.iso", imageType, version, arch)
 }
 
 func buildRootfsURL(baseURL, arch, version string) (string, error) {
@@ -515,9 +581,9 @@ func (s *rhcosStore) cleanDataDir() error {
 	var expectedFiles []string
 	for _, version := range s.versions {
 		// Only add full isos here as we want to regenerate the minimal image on each deploy
-		expectedFiles = append(expectedFiles, isoFileName(ImageTypeFull, version["openshift_version"], version["version"], version["cpu_architecture"]))
+		expectedFiles = append(expectedFiles, isoFileName(ImageTypeFull, version["version"], version["cpu_architecture"]))
 		// Keep nmstatectl cached files for all architectures (including s390x)
-		expectedFiles = append(expectedFiles, nmstatectlFileName(version["openshift_version"], version["version"], version["cpu_architecture"]))
+		expectedFiles = append(expectedFiles, nmstatectlFileName(version["version"], version["cpu_architecture"]))
 	}
 
 	dataDirFiles, err := os.ReadDir(s.dataDir)
@@ -539,24 +605,16 @@ func (s *rhcosStore) cleanDataDir() error {
 }
 
 func (s *rhcosStore) HaveVersion(version, arch string) bool {
-	for _, entry := range s.versions {
-		v, versionPresent := entry["openshift_version"]
-		a, archPresent := entry["cpu_architecture"]
-		if versionPresent && v == version && archPresent && a == arch {
-			return true
-		}
-	}
-	return false
+	return s.findVersionEntry(version, arch) != nil
 }
 
-func (s *rhcosStore) NmstatectlPathForParams(openshiftVersion, arch string) (string, error) {
-	var version string
-	for _, entry := range s.versions {
-		if entry["openshift_version"] == openshiftVersion && entry["cpu_architecture"] == arch {
-			version = entry["version"]
-		}
+func (s *rhcosStore) NmstatectlPathForParams(versionKey, arch string) (string, error) {
+	rhcosVersion := versionKey
+	entry := s.findVersionEntry(versionKey, arch)
+	if entry != nil {
+		rhcosVersion = entry["version"]
 	}
-	nmstatectlPath := filepath.Join(s.dataDir, nmstatectlFileName(openshiftVersion, version, arch))
+	nmstatectlPath := filepath.Join(s.dataDir, nmstatectlFileName(rhcosVersion, arch))
 
 	// Safety check: ensures nmstatectlPath stays within the expected dataDir,
 	// preventing crafted inputs from escaping the intended directory
@@ -566,6 +624,6 @@ func (s *rhcosStore) NmstatectlPathForParams(openshiftVersion, arch string) (str
 	return nmstatectlPath, nil
 }
 
-func nmstatectlFileName(openshiftVersion, version, arch string) string {
-	return fmt.Sprintf("nmstatectl-%s-%s-%s", openshiftVersion, version, arch)
+func nmstatectlFileName(version, arch string) string {
+	return fmt.Sprintf("nmstatectl-%s-%s", version, arch)
 }

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -25,8 +25,9 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 	"go.uber.org/mock/gomock"
+
+	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 )
 
 var (
@@ -183,13 +184,13 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, caCertFileName, osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
+				rootfs := fmt.Sprintf(rootfsURL, version["version"])
 				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
-				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
+				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(content).To(Equal(isoContent))
 			})
@@ -281,13 +282,13 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
+				rootfs := fmt.Sprintf(rootfsURL, version["version"])
 				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
-				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
+				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(content).To(Equal(isoContent))
 			})
@@ -310,13 +311,13 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
+				rootfs := fmt.Sprintf(rootfsURL, version["version"])
 				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
-				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
+				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(content).To(Equal(isoContent))
 			})
@@ -333,13 +334,13 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
+				rootfs := fmt.Sprintf(rootfsURL, version["version"])
 				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
-				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
+				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(content).To(Equal(isoContent))
 			})
@@ -372,7 +373,7 @@ var _ = Context("with a data directory configured", func() {
 
 				Expect(is.Populate(ctx)).NotTo(Succeed())
 
-				_, err = os.Stat(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
+				_, err = os.Stat(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
 				Expect(err).To(MatchError(fs.ErrNotExist))
 			})
 
@@ -387,7 +388,7 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
+				rootfs := fmt.Sprintf(rootfsURL, version["version"])
 				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(fmt.Errorf("minimal iso creation failed"))
@@ -405,9 +406,9 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
+				rootfs := fmt.Sprintf(rootfsURL, version["version"])
 				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
@@ -418,13 +419,13 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				fullPath := filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso")
+				fullPath := filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso")
 				Expect(os.WriteFile(fullPath, []byte("moreisocontent"), 0600)).To(Succeed())
 
-				minimalPath := filepath.Join(dataDir, "rhcos-minimal-iso-4.8-48.84.202109241901-0-x86_64.iso")
+				minimalPath := filepath.Join(dataDir, "rhcos-minimal-iso-48.84.202109241901-0-x86_64.iso")
 				Expect(os.WriteFile(minimalPath, []byte("minimalisocontent"), 0600)).To(Succeed())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
+				rootfs := fmt.Sprintf(rootfsURL, version["version"])
 				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(fullPath, rootfs, "x86_64", minimalPath, version["openshift_version"], nmstatectlPath).Return(nil)
@@ -444,13 +445,13 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{versionPatch}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, versionPatch["openshift_version"])
+				rootfs := fmt.Sprintf(rootfsURL, versionPatch["version"])
 				nmstatectlPath, err := is.NmstatectlPathForParams(versionPatch["openshift_version"], versionPatch["cpu_architecture"])
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), versionPatch["openshift_version"], nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
-				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-4.8.1-48.84.202109241901-0-x86_64.iso"))
+				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(content).To(Equal(isoContent))
 			})
@@ -469,7 +470,7 @@ var _ = Context("with a data directory configured", func() {
 					is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{versionPatch}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 					Expect(err).NotTo(HaveOccurred())
 
-					rootfs := fmt.Sprintf(rootfsURL, versionPatch["openshift_version"])
+					rootfs := fmt.Sprintf(rootfsURL, versionPatch["version"])
 					nmstatectlPath, err := is.NmstatectlPathForParams(versionPatch["openshift_version"], versionPatch["cpu_architecture"])
 					Expect(err).NotTo(HaveOccurred())
 					mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), versionPatch["openshift_version"], nmstatectlPath).Return(nil)
@@ -493,12 +494,12 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to validate boot artifacts"))
 
-				_, err = os.Stat(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
+				_, err = os.Stat(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
 				Expect(err).To(MatchError(fs.ErrNotExist))
 			})
 
 			It("cleans up files that are not configured isos", func() {
-				oldISOPath := filepath.Join(dataDir, "rhcos-full-iso-4.7-47.84.202109241831-0-x86_64.iso")
+				oldISOPath := filepath.Join(dataDir, "rhcos-full-iso-47.84.202109241831-0-x86_64.iso")
 				Expect(os.WriteFile(oldISOPath, []byte("oldisocontent"), 0600)).To(Succeed())
 
 				isoContent, isoHeader := readTestISO(validVolumeID)
@@ -512,7 +513,7 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["openshift_version"])
+				rootfs := fmt.Sprintf(rootfsURL, version["version"])
 				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
@@ -537,7 +538,7 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("unexpected EOF"))
 
-				_, err = os.Stat(filepath.Join(dataDir, "rhcos-full-iso-4.8-48.84.202109241901-0-x86_64.iso"))
+				_, err = os.Stat(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
 				Expect(err).To(MatchError(fs.ErrNotExist))
 			})
 
@@ -563,7 +564,7 @@ var _ = Context("with a data directory configured", func() {
 				is, err := NewImageStore(mockEditor, dataDir, baseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).ToNot(HaveOccurred())
 
-				rootfs := fmt.Sprintf("https://images.example.com/api/assisted-images/boot-artifacts/rootfs?arch=x86_64&version=%s", version["openshift_version"])
+				rootfs := fmt.Sprintf("https://images.example.com/api/assisted-images/boot-artifacts/rootfs?arch=x86_64&version=%s", version["version"])
 				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), gomock.Any(), nmstatectlPath).Return(nil)
@@ -631,7 +632,7 @@ var _ = Context("with a data directory configured", func() {
 					Expect(os.WriteFile(nmstatectlPath, []byte(cacheContent), 0755)).To(Succeed()) //nolint:gosec
 
 					// Mock minimal ISO creation
-					expectedRootfs := fmt.Sprintf("http://images.example.com/boot-artifacts/rootfs?arch=%s&version=%s", arch, archVersion["openshift_version"])
+					expectedRootfs := fmt.Sprintf("http://images.example.com/boot-artifacts/rootfs?arch=%s&version=%s", arch, archVersion["version"])
 					mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), expectedRootfs, arch, gomock.Any(), archVersion["openshift_version"], nmstatectlPath).Return(nil)
 					// If nmstatectl is cached, BuildNmstateCpioArchive must not be called.
 					mockNmstateHandler.EXPECT().BuildNmstateCpioArchive(gomock.Any()).Times(0)
@@ -672,7 +673,7 @@ var _ = Context("with a data directory configured", func() {
 })
 
 var _ = Describe("PathForParams", func() {
-	It("creates the correct path", func() {
+	It("creates the correct path when looked up by openshift version", func() {
 		versions := []map[string]string{{
 			"openshift_version": "4.8",
 			"cpu_architecture":  "x86_64",
@@ -681,8 +682,21 @@ var _ = Describe("PathForParams", func() {
 		}}
 		is, err := NewImageStore(nil, "/tmp/some/dir", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).NotTo(HaveOccurred())
-		expected := "/tmp/some/dir/rhcos-full-4.8-48.84.202109241901-0-x86_64.iso"
+		expected := "/tmp/some/dir/rhcos-full-48.84.202109241901-0-x86_64.iso"
 		Expect(is.PathForParams("full", "4.8", "x86_64")).To(Equal(expected))
+	})
+
+	It("creates the correct path when looked up by RHCOS version", func() {
+		versions := []map[string]string{{
+			"openshift_version": "4.8",
+			"cpu_architecture":  "x86_64",
+			"url":               "http://example.com/image/x86_64-48.iso",
+			"version":           "48.84.202109241901-0",
+		}}
+		is, err := NewImageStore(nil, "/tmp/some/dir", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		expected := "/tmp/some/dir/rhcos-full-48.84.202109241901-0-x86_64.iso"
+		Expect(is.PathForParams("full", "48.84.202109241901-0", "x86_64")).To(Equal(expected))
 	})
 })
 
@@ -725,12 +739,47 @@ var _ = Describe("HaveVersion", func() {
 		Expect(store.HaveVersion("4.15", "s390x")).To(BeTrue())
 	})
 
+	It("is true when looked up by RHCOS version", func() {
+		Expect(store.HaveVersion("48.84.202109241901-0", "x86_64")).To(BeTrue())
+		Expect(store.HaveVersion("49.84.202110081407-0", "arm64")).To(BeTrue())
+		Expect(store.HaveVersion("415.92.202403212258-0", "s390x")).To(BeTrue())
+	})
+
 	It("is false for versions that are missing", func() {
 		Expect(store.HaveVersion("4.9", "x86_64")).To(BeFalse())
 		Expect(store.HaveVersion("4.8", "arm64")).To(BeFalse())
 		Expect(store.HaveVersion("4.7", "x86_64")).To(BeFalse())
 		Expect(store.HaveVersion("4.8", "aarch64")).To(BeFalse())
 		Expect(store.HaveVersion("4.11", "s390x")).To(BeFalse())
+	})
+})
+
+var _ = Describe("deduplicateVersions", func() {
+	It("keeps the entry with the highest openshift_version per RHCOS version and architecture", func() {
+		versions := []map[string]string{
+			{
+				"openshift_version": "4.10",
+				"cpu_architecture":  "x86_64",
+				"url":               "http://example.com/first.iso",
+				"version":           "410.84.202201251210-0",
+			},
+			{
+				"openshift_version": "4.10.1",
+				"cpu_architecture":  "x86_64",
+				"url":               "http://example.com/second.iso",
+				"version":           "410.84.202201251210-0",
+			},
+			{
+				"openshift_version": "4.11",
+				"cpu_architecture":  "arm64",
+				"url":               "http://example.com/arm64.iso",
+				"version":           "411.86.202204190940-0",
+			},
+		}
+		dedupedVersions := deduplicateVersions(versions)
+		Expect(dedupedVersions).To(HaveLen(2))
+		Expect(dedupedVersions).To(ContainElement(HaveKeyWithValue("url", "http://example.com/second.iso")))
+		Expect(dedupedVersions).To(ContainElement(HaveKeyWithValue("openshift_version", "4.10.1")))
 	})
 })
 
@@ -980,14 +1029,14 @@ var _ = Context("cleanDataDir", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create expected files
-		fullISOx86 := filepath.Join(dataDir, "rhcos-full-iso-4.18-418.84.202109241901-0-x86_64.iso")
-		fullISOs390x := filepath.Join(dataDir, "rhcos-full-iso-4.18-418.92.202403212258-0-s390x.iso")
-		fullISOarm64 := filepath.Join(dataDir, "rhcos-full-iso-4.18-418.84.202109241901-0-arm64.iso")
-		fullISOppc64le := filepath.Join(dataDir, "rhcos-full-iso-4.18-418.84.202109241901-0-ppc64le.iso")
-		nmstatectlx86 := filepath.Join(dataDir, "nmstatectl-4.18-418.84.202109241901-0-x86_64")
-		nmstatectls390x := filepath.Join(dataDir, "nmstatectl-4.18-418.92.202403212258-0-s390x")
-		nmstatectlarm64 := filepath.Join(dataDir, "nmstatectl-4.18-418.84.202109241901-0-arm64")
-		nmstatectlppc64le := filepath.Join(dataDir, "nmstatectl-4.18-418.84.202109241901-0-ppc64le")
+		fullISOx86 := filepath.Join(dataDir, "rhcos-full-iso-418.84.202109241901-0-x86_64.iso")
+		fullISOs390x := filepath.Join(dataDir, "rhcos-full-iso-418.92.202403212258-0-s390x.iso")
+		fullISOarm64 := filepath.Join(dataDir, "rhcos-full-iso-418.84.202109241901-0-arm64.iso")
+		fullISOppc64le := filepath.Join(dataDir, "rhcos-full-iso-418.84.202109241901-0-ppc64le.iso")
+		nmstatectlx86 := filepath.Join(dataDir, "nmstatectl-418.84.202109241901-0-x86_64")
+		nmstatectls390x := filepath.Join(dataDir, "nmstatectl-418.92.202403212258-0-s390x")
+		nmstatectlarm64 := filepath.Join(dataDir, "nmstatectl-418.84.202109241901-0-arm64")
+		nmstatectlppc64le := filepath.Join(dataDir, "nmstatectl-418.84.202109241901-0-ppc64le")
 
 		// Create files that should be kept
 		Expect(os.WriteFile(fullISOx86, []byte("iso-content-x86"), 0600)).To(Succeed())
@@ -1000,8 +1049,8 @@ var _ = Context("cleanDataDir", func() {
 		Expect(os.WriteFile(nmstatectlppc64le, []byte("nmstatectl-ppc64le"), 0755)).To(Succeed()) //nolint:gosec
 
 		// Create files that should be removed
-		oldISO := filepath.Join(dataDir, "rhcos-full-iso-4.7-47.84.202109241831-0-x86_64.iso")
-		minimalISO := filepath.Join(dataDir, "rhcos-minimal-iso-4.8-48.84.202109241901-0-x86_64.iso")
+		oldISO := filepath.Join(dataDir, "rhcos-full-iso-47.84.202109241831-0-x86_64.iso")
+		minimalISO := filepath.Join(dataDir, "rhcos-minimal-iso-48.84.202109241901-0-x86_64.iso")
 		randomFile := filepath.Join(dataDir, "random-file.txt")
 
 		Expect(os.WriteFile(oldISO, []byte("old-iso"), 0600)).To(Succeed())
@@ -1115,7 +1164,7 @@ var _ = Describe("Populate with disconnected ISO", func() {
 			err = is.Populate(ctx)
 			Expect(err).To(Succeed())
 
-			content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-disconnected-iso-4.8-48.84.202109241901-0-x86_64.iso"))
+			content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-disconnected-iso-48.84.202109241901-0-x86_64.iso"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(content).To(Equal(isoContent))
 		})


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

We're still going to allow getting OS Images by openshift version, but we want to also allow and prioritize getting them by RHCOS version.
We also don't want to keep in our storage multiple ISOs that are identical which happen when different openshift versions use the same RHCOS version, so we're going to dedup them before populating the image store.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

Manually installed clusters with both full and minimal ISOs.
I had 2 openshift versions with the same RHCOS version, I could get the ISO for both of them and the storage directory only had a single copy.

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->

Closes [MGMT-24783](https://redhat.atlassian.net/browse/MGMT-24783)

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ISO generation by deduplicating configured entries per version and architecture, reducing conflicting downloads and inconsistent results.
  * Standardized ISO, cache, and nmstatectl naming to align download, validation, and cleanup behavior.
  * Enhanced cache/path resolution for more reliable retrieval of required artifacts.
* **New Features**
  * Minimal ISO creation now uses a streamlined version lookup flow, supporting both version and effective OpenShift version matching.
  * Path resolution improved to correctly handle version/architecture inputs for consistent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->