### PR TITLE
APPSRE-13041: Add monitoring.rhobs/v1 ServiceMonitor for COO

### DIFF
--- a/deploy/template-monitoring.yaml
+++ b/deploy/template-monitoring.yaml
@@ -26,3 +26,21 @@ objects:
     selector:
       matchLabels:
         name: assisted-image-service
+- apiVersion: monitoring.rhobs/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      prometheus: app-sre
+    name: servicemonitor-image-service-coo
+  spec:
+    endpoints:
+    - interval: 30s
+      path: /metrics
+      port: image-service
+      scheme: http
+    namespaceSelector:
+      matchNames:
+      - ${NAMESPACE}
+    selector:
+      matchLabels:
+        name: assisted-image-service


### PR DESCRIPTION
## What

Adds a `monitoring.rhobs/v1` `ServiceMonitor` (`servicemonitor-image-service-coo`) alongside the existing `monitoring.coreos.com/v1` one in `deploy/template-monitoring.yaml`.

## Why

App-SRE is migrating its Prometheus stack to the [Cluster Observability Operator](https://github.com/rhobs/observability-operator) (COO), which discovers `ServiceMonitor`s via the `monitoring.rhobs` API group instead of `monitoring.coreos.com`. Without this change, `assisted-image-service` metrics stop being scraped once App-SRE cuts over to COO — confirmed via a parity check comparing scrape coverage between the legacy and COO Prometheus stacks, which reported `assisted-image-service` as missing in COO on `app-sre-prod-04`/`app-sre-stage-01`.

Both `app-sre-prod-04` and `app-sre-stage-01`'s target namespaces already allow the `ServiceMonitor.monitoring.rhobs` resource type on the App-SRE side, so no other changes are needed for this to take effect once merged and released.

## Test plan

- [x] `oc process --local -f deploy/template-monitoring.yaml -p NAMESPACE=assisted-installer-production` — confirmed both ServiceMonitor objects render correctly with the namespace substituted

## Cleanup

Once COO scraping is confirmed working, the legacy `monitoring.coreos.com/v1` ServiceMonitor should be removed from this file. Tracked in https://redhat.atlassian.net/browse/APPSRE-14688.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring coverage for the assisted image service.
  * The service’s metrics endpoint is now automatically discovered and scraped every 30 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->