### PR TITLE
MGMT-24567: adding optional parameter to the template

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -133,6 +133,9 @@ parameters:
   value: "6Gi"
 - name: PDB_MIN_AVAILABLE
   value: "2"
+- name: OS_IMAGES_REQUEST_HEADERS
+  value: ''
+  required: false
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -177,6 +180,8 @@ objects:
             value: "8080"
           - name: RHCOS_VERSIONS
             value: ${OS_IMAGES}
+          - name: OS_IMAGES_REQUEST_HEADERS
+            value: ${OS_IMAGES_REQUEST_HEADERS}
           - name: ASSISTED_SERVICE_SCHEME
             value: http
           - name: ASSISTED_SERVICE_HOST


### PR DESCRIPTION
Adding the optional parameter OS_IMAGES_REQUEST_HEADERS to the template so it could recieve the value from app-interface.

## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for custom request headers when retrieving operating system images.
  * The setting defaults to empty and can be provided during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->