### PR TITLE
NO-ISSUE: Ensure that kargs end with newline

### DIFF
--- a/pkg/isoeditor/stream.go
+++ b/pkg/isoeditor/stream.go
@@ -39,7 +39,10 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 		}
 	}
 
-	if kargs != nil {
+	if len(kargs) > 0 {
+		if kargs[len(kargs)-1] != '\n' {
+			kargs = append(kargs, '\n')
+		}
 		files, err := KargsFiles(isoPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read files to patch for kernel arguments")

--- a/pkg/isoeditor/stream_test.go
+++ b/pkg/isoeditor/stream_test.go
@@ -102,6 +102,65 @@ var _ = Describe("NewRHCOSStreamReader", func() {
 		}
 	})
 
+	It("appends a newline to kargs content if missing", func() {
+		kargsNoNewline := []byte(" p1 p2 p3 p4")
+		kargsWithNewline := []byte(" p1 p2 p3 p4\n")
+		streamReader, err := NewRHCOSStreamReader(isoFile, &IgnitionContent{Config: ignitionContent}, nil, kargsNoNewline)
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err := os.CreateTemp(filesDir, "streamed*.iso")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = io.Copy(f, streamReader)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(f.Sync()).To(Succeed())
+		Expect(f.Close()).To(Succeed())
+
+		Expect(isoFileContent(f.Name(), ignitionImagePath)).To(Equal(ignitionArchiveBytes))
+		grubFileContent := string(isoFileContent(f.Name(), defaultGrubFilePath))
+		isolinuxContent := string(isoFileContent(f.Name(), defaultIsolinuxFilePath))
+		for _, content := range []string{grubFileContent, isolinuxContent} {
+			Expect(content).To(MatchRegexp(string(kargsWithNewline) + "#+ COREOS_KARG_EMBED_AREA"))
+		}
+	})
+
+	It("succeeds with nil kargs", func() {
+		streamReader, err := NewRHCOSStreamReader(isoFile, &IgnitionContent{Config: ignitionContent}, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err := os.CreateTemp(filesDir, "streamed*.iso")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = io.Copy(f, streamReader)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(f.Sync()).To(Succeed())
+		Expect(f.Close()).To(Succeed())
+
+		Expect(isoFileContent(f.Name(), ignitionImagePath)).To(Equal(ignitionArchiveBytes))
+		grubFileContent := string(isoFileContent(f.Name(), defaultGrubFilePath))
+		isolinuxContent := string(isoFileContent(f.Name(), defaultIsolinuxFilePath))
+		for _, content := range []string{grubFileContent, isolinuxContent} {
+			Expect(content).To(MatchRegexp("\n#+ COREOS_KARG_EMBED_AREA"))
+		}
+	})
+
+	It("succeeds with empty kargs", func() {
+		streamReader, err := NewRHCOSStreamReader(isoFile, &IgnitionContent{Config: ignitionContent}, nil, []byte{})
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err := os.CreateTemp(filesDir, "streamed*.iso")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = io.Copy(f, streamReader)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(f.Sync()).To(Succeed())
+		Expect(f.Close()).To(Succeed())
+
+		Expect(isoFileContent(f.Name(), ignitionImagePath)).To(Equal(ignitionArchiveBytes))
+		grubFileContent := string(isoFileContent(f.Name(), defaultGrubFilePath))
+		isolinuxContent := string(isoFileContent(f.Name(), defaultIsolinuxFilePath))
+		for _, content := range []string{grubFileContent, isolinuxContent} {
+			Expect(content).To(MatchRegexp("\n#+ COREOS_KARG_EMBED_AREA"))
+		}
+	})
+
 	It("Embeds the ignition in a ISO that uses the 'igninfo.json' file", func() {
 		// Create input ISO:
 		tmpDir, inputFile := createS390TestFiles("Assisted123", 0)


### PR DESCRIPTION
In NewRHCOSStreamReader() we overlay the newline at the end of the current kargs with the kargs string to append. Currently, the consumer of the API is required to always pass a newline at the end of the list of kargs to append. If the consumer fails to do so, the kargs will end with the comment markers directly instead of a newline with the comment markers on the next line. This produces an ISO that cannot itself be further streamed with a second call to NewRHCOSStreamReader() passing additional kargs to add, because kargsEmbedAreaBoundariesFinder() looks for the newline as the start of the embed area.

As a defensive measure, add a newline if the caller has not supplied one. This makes NewRHCOSStreamReader() consistent with other APIs, such as NewKargsReader().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of kernel arguments when creating RHCOS streams.
  * Kernel-argument processing is now skipped when no kernel arguments are provided (nil or empty).
  * When kernel arguments are provided without a trailing newline, the embedded content is normalized to include the newline before it’s written.
* **Tests**
  * Added Ginkgo coverage to verify newline normalization and correct behavior when kernel arguments are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->