### PR TITLE
MGMT-24904: Check image type when deduplicating

### DIFF
--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -386,14 +386,18 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 	return nil
 }
 
-// deduplicateVersions keeps a single entry per RHCOS version and CPU architecture pair.
+// deduplicateVersions keeps a single entry per RHCOS version, CPU architecture pair and image type.
 // When multiple pairs share the same RHCOS image, the entry with the highest openshift_version is kept.
 // It's important to keep that entry because the openshift_version is used to decide if we want the nmstatectl for that entry.
 func deduplicateVersions(versions []map[string]string) []map[string]string {
 	m := make(map[string]map[string]string, len(versions))
 
 	for _, entry := range versions {
-		key := entry["version"] + "@" + entry["cpu_architecture"]
+		imageType := entry["type"]
+		if imageType == "" {
+			imageType = ImageTypeFull
+		}
+		key := entry["version"] + "@" + entry["cpu_architecture"] + "@" + imageType
 		existing, ok := m[key]
 		if !ok {
 			m[key] = entry
@@ -402,21 +406,21 @@ func deduplicateVersions(versions []map[string]string) []map[string]string {
 		greater, err := common.VersionGreaterOrEqual(entry["openshift_version"], existing["openshift_version"])
 		if err != nil {
 			log.Debugf(
-				"Couldn't check if OS image entry for RHCOS version %s and architecture %s with openshift_version %s has a greater openshift version, keeping %s, error: %v",
-				entry["version"], entry["cpu_architecture"], entry["openshift_version"], existing["openshift_version"], err,
+				"Couldn't check if OS image entry for key %s with openshift_version %s has a greater openshift version, keeping %s, error: %v",
+				key, entry["openshift_version"], existing["openshift_version"], err,
 			)
 			continue
 		}
 		if greater {
 			log.Debugf(
-				"Replacing duplicate OS image entry for RHCOS version %s and architecture %s with openshift_version %s (was %s)",
-				entry["version"], entry["cpu_architecture"], entry["openshift_version"], existing["openshift_version"],
+				"Replacing duplicate OS image entry for key %s with openshift_version %s (was %s)",
+				key, entry["openshift_version"], existing["openshift_version"],
 			)
 			m[key] = entry
 		} else {
 			log.Debugf(
-				"Skipping duplicate OS image entry for RHCOS version %s and architecture %s (openshift_version %s, keeping %s)",
-				entry["version"], entry["cpu_architecture"], entry["openshift_version"], existing["openshift_version"],
+				"Skipping duplicate OS image entry for key %s (openshift_version %s, keeping %s)",
+				key, entry["openshift_version"], existing["openshift_version"],
 			)
 		}
 	}

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -781,6 +781,28 @@ var _ = Describe("deduplicateVersions", func() {
 		Expect(dedupedVersions).To(ContainElement(HaveKeyWithValue("url", "http://example.com/second.iso")))
 		Expect(dedupedVersions).To(ContainElement(HaveKeyWithValue("openshift_version", "4.10.1")))
 	})
+
+	It("keeps 2 entries with the same RHCOS version and architecture but different image types", func() {
+		versions := []map[string]string{
+			{
+				"openshift_version": "4.10",
+				"cpu_architecture":  "x86_64",
+				"url":               "http://example.com/disconnected.iso",
+				"version":           "410.84.202201251210-0",
+				"type":              "disconnected-iso",
+			},
+			{
+				"openshift_version": "4.10",
+				"cpu_architecture":  "x86_64",
+				"url":               "http://example.com/full.iso",
+				"version":           "410.84.202201251210-0",
+			},
+		}
+		dedupedVersions := deduplicateVersions(versions)
+		Expect(dedupedVersions).To(HaveLen(2))
+		Expect(dedupedVersions).To(ContainElement(HaveKeyWithValue("url", "http://example.com/disconnected.iso")))
+		Expect(dedupedVersions).To(ContainElement(HaveKeyWithValue("url", "http://example.com/full.iso")))
+	})
 })
 
 var _ = Describe("NewImageStore", func() {


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

In cases where our configuration includes a full iso and a disconnected iso with the same RHCOS version and CPU architecture, we need to include both of them after our deduplication.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->

Closes [MGMT-24904](https://redhat.atlassian.net/browse/MGMT-24904)

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected image version deduplication so entries with different image types are retained separately.
  * Preserved selection of the highest OpenShift version when otherwise-duplicate entries are found.
  * Added coverage for image-type-specific deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->