### PR TITLE
MGMT-24907: Use openshift version to check if version is high enough for nmstate

### DIFF
--- a/internal/handlers/initrd.go
+++ b/internal/handlers/initrd.go
@@ -92,7 +92,12 @@ func initrdOverlayReader(imageStore imagestore.ImageStore, client *AssistedServi
 			return nil, "", http.StatusInternalServerError, fmt.Errorf("failed to create append reader for initrd: %v", err)
 		}
 
-		versionOK, err := common.VersionGreaterOrEqual(version, isoeditor.MinimalVersionForNmstatectl)
+		openshiftVersion, err := imageStore.OpenshiftVersionForParams(version, arch)
+		if err != nil {
+			return nil, "", http.StatusBadRequest, err
+		}
+
+		versionOK, err := common.VersionGreaterOrEqual(openshiftVersion, isoeditor.MinimalVersionForNmstatectl)
 		if err != nil {
 			return nil, "", http.StatusInternalServerError, err
 		}

--- a/internal/handlers/initrd_addrsize_test.go
+++ b/internal/handlers/initrd_addrsize_test.go
@@ -12,8 +12,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-	"github.com/openshift/assisted-image-service/pkg/imagestore"
 	"go.uber.org/mock/gomock"
+
+	"github.com/openshift/assisted-image-service/pkg/imagestore"
 )
 
 var _ = Describe("ServeHTTP", func() {
@@ -86,6 +87,7 @@ var _ = Describe("ServeHTTP", func() {
 	mockImage := func(version, arch string) {
 		mockImageStore.EXPECT().HaveVersion(version, arch).Return(true).AnyTimes()
 		mockImageStore.EXPECT().PathForParams(imagestore.ImageTypeFull, version, arch).Return(imageFilename).AnyTimes()
+		mockImageStore.EXPECT().OpenshiftVersionForParams(version, arch).Return(version, nil).AnyTimes()
 	}
 
 	expectSuccessfulResponse := func(resp *http.Response, content []byte) {

--- a/internal/handlers/initrd_test.go
+++ b/internal/handlers/initrd_test.go
@@ -12,8 +12,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-	"github.com/openshift/assisted-image-service/pkg/imagestore"
 	"go.uber.org/mock/gomock"
+
+	"github.com/openshift/assisted-image-service/pkg/imagestore"
 )
 
 var _ = Describe("ServeHTTP", func() {
@@ -93,6 +94,7 @@ var _ = Describe("ServeHTTP", func() {
 	mockImage := func(version, arch string) {
 		mockImageStore.EXPECT().HaveVersion(version, arch).Return(true).AnyTimes()
 		mockImageStore.EXPECT().PathForParams(imagestore.ImageTypeFull, version, arch).Return(imageFilename).AnyTimes()
+		mockImageStore.EXPECT().OpenshiftVersionForParams(version, arch).Return(version, nil).AnyTimes()
 	}
 
 	expectSuccessfulResponse := func(resp *http.Response, content []byte) {
@@ -205,6 +207,23 @@ var _ = Describe("ServeHTTP", func() {
 		)
 		mockImageStore.EXPECT().NmstatectlPathForParams("4.18", "x86_64").Return(nmstatectlPathForCaching, nil).AnyTimes()
 		resp, err := client.Get(fmt.Sprintf("%s/images/%s/pxe-initrd?version=4.18&arch=x86_64", server.URL, imageID))
+		Expect(err).NotTo(HaveOccurred())
+		expectSuccessfulResponse(resp, append(append(append(initrdContent, ignitionArchiveBytes...), minimalInitrdContent...), nmstatectlContent...))
+	})
+
+	It("includes nmstatectl when looked up by RHCOS version that maps to a supported OCP version", func() {
+		rhcosVersion := "418.94.202410010000-0"
+		mockImageStore.EXPECT().HaveVersion(rhcosVersion, "x86_64").Return(true).AnyTimes()
+		mockImageStore.EXPECT().PathForParams(imagestore.ImageTypeFull, rhcosVersion, "x86_64").Return(imageFilename).AnyTimes()
+		mockImageStore.EXPECT().OpenshiftVersionForParams(rhcosVersion, "x86_64").Return("4.18", nil).AnyTimes()
+		assistedServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/downloads/minimal-initrd", imageID)),
+				ghttp.RespondWith(http.StatusOK, minimalInitrdContent),
+			),
+		)
+		mockImageStore.EXPECT().NmstatectlPathForParams(rhcosVersion, "x86_64").Return(nmstatectlPathForCaching, nil).AnyTimes()
+		resp, err := client.Get(fmt.Sprintf("%s/images/%s/pxe-initrd?version=%s&arch=x86_64", server.URL, imageID, rhcosVersion))
 		Expect(err).NotTo(HaveOccurred())
 		expectSuccessfulResponse(resp, append(append(append(initrdContent, ignitionArchiveBytes...), minimalInitrdContent...), nmstatectlContent...))
 	})

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -73,7 +73,8 @@ type ImageStore interface {
 	Populate(ctx context.Context) error
 	PathForParams(imageType, version, arch string) string
 	HaveVersion(version, arch string) bool
-	NmstatectlPathForParams(openshiftVersion, arch string) (string, error)
+	OpenshiftVersionForParams(version, arch string) (string, error)
+	NmstatectlPathForParams(version, arch string) (string, error)
 }
 
 type rhcosStore struct {
@@ -546,9 +547,9 @@ func (s *rhcosStore) findVersionEntry(versionKey, arch string) map[string]string
 	return nil
 }
 
-func (s *rhcosStore) PathForParams(imageType, versionKey, arch string) string {
-	rhcosVersion := versionKey
-	entry := s.findVersionEntry(versionKey, arch)
+func (s *rhcosStore) PathForParams(imageType, version, arch string) string {
+	rhcosVersion := version
+	entry := s.findVersionEntry(version, arch)
 	if entry != nil {
 		rhcosVersion = entry["version"]
 	}
@@ -608,9 +609,50 @@ func (s *rhcosStore) HaveVersion(version, arch string) bool {
 	return s.findVersionEntry(version, arch) != nil
 }
 
-func (s *rhcosStore) NmstatectlPathForParams(versionKey, arch string) (string, error) {
-	rhcosVersion := versionKey
-	entry := s.findVersionEntry(versionKey, arch)
+// OpenshiftVersionForParams returns the OpenShift version associated with the given version
+// and CPU architecture. The version may be an RHCOS version or an OpenShift version. When multiple
+// entries share the same RHCOS version, the highest OpenShift version is returned.
+func (s *rhcosStore) OpenshiftVersionForParams(version, arch string) (string, error) {
+	var highest string
+	for _, entry := range s.versions {
+		if entry["cpu_architecture"] != arch {
+			continue
+		}
+		if entry["version"] != version {
+			continue
+		}
+		openshiftVersion := entry["openshift_version"]
+		if highest == "" {
+			highest = openshiftVersion
+			continue
+		}
+		greater, err := common.VersionGreaterOrEqual(openshiftVersion, highest)
+		if err != nil {
+			continue
+		}
+		if greater {
+			highest = openshiftVersion
+		}
+	}
+	if highest != "" {
+		return highest, nil
+	}
+
+	for _, entry := range s.versions {
+		if entry["cpu_architecture"] != arch {
+			continue
+		}
+		if entry["openshift_version"] == version {
+			return version, nil
+		}
+	}
+
+	return "", fmt.Errorf("openshift version for version %s and architecture %s not found", version, arch)
+}
+
+func (s *rhcosStore) NmstatectlPathForParams(version, arch string) (string, error) {
+	rhcosVersion := version
+	entry := s.findVersionEntry(version, arch)
 	if entry != nil {
 		rhcosVersion = entry["version"]
 	}

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -754,6 +754,58 @@ var _ = Describe("HaveVersion", func() {
 	})
 })
 
+var _ = Describe("OpenshiftVersionForParams", func() {
+	var store ImageStore
+
+	BeforeEach(func() {
+		var err error
+		store, err = NewImageStore(nil, "", imageServiceBaseURL, false, []map[string]string{
+			{
+				"openshift_version": "4.14",
+				"cpu_architecture":  "x86_64",
+				"url":               "http://example.com/image/x86_64-shared.iso",
+				"version":           "shared-rhcos",
+			},
+			{
+				"openshift_version": "4.16.2",
+				"cpu_architecture":  "x86_64",
+				"url":               "http://example.com/image/x86_64-shared.iso",
+				"version":           "shared-rhcos",
+			},
+			{
+				"openshift_version": "4.15.1",
+				"cpu_architecture":  "x86_64",
+				"url":               "http://example.com/image/x86_64-shared.iso",
+				"version":           "shared-rhcos",
+			},
+			{
+				"openshift_version": "4.18",
+				"cpu_architecture":  "arm64",
+				"url":               "http://example.com/image/arm64.iso",
+				"version":           "arm-rhcos",
+			},
+		}, "", map[string]string{}, map[string]string{}, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns the highest OpenShift version for a shared RHCOS version", func() {
+		openshiftVersion, err := store.OpenshiftVersionForParams("shared-rhcos", "x86_64")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(openshiftVersion).To(Equal("4.16.2"))
+	})
+
+	It("returns the OpenShift version when looked up by OpenShift version", func() {
+		openshiftVersion, err := store.OpenshiftVersionForParams("4.18", "arm64")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(openshiftVersion).To(Equal("4.18"))
+	})
+
+	It("fails for unsupported version", func() {
+		_, err := store.OpenshiftVersionForParams("missing", "x86_64")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
 var _ = Describe("deduplicateVersions", func() {
 	It("keeps the entry with the highest openshift_version per RHCOS version and architecture", func() {
 		versions := []map[string]string{

--- a/pkg/imagestore/mock_imagestore.go
+++ b/pkg/imagestore/mock_imagestore.go
@@ -55,18 +55,33 @@ func (mr *MockImageStoreMockRecorder) HaveVersion(version, arch any) *gomock.Cal
 }
 
 // NmstatectlPathForParams mocks base method.
-func (m *MockImageStore) NmstatectlPathForParams(openshiftVersion, arch string) (string, error) {
+func (m *MockImageStore) NmstatectlPathForParams(version, arch string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NmstatectlPathForParams", openshiftVersion, arch)
+	ret := m.ctrl.Call(m, "NmstatectlPathForParams", version, arch)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NmstatectlPathForParams indicates an expected call of NmstatectlPathForParams.
-func (mr *MockImageStoreMockRecorder) NmstatectlPathForParams(openshiftVersion, arch any) *gomock.Call {
+func (mr *MockImageStoreMockRecorder) NmstatectlPathForParams(version, arch any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NmstatectlPathForParams", reflect.TypeOf((*MockImageStore)(nil).NmstatectlPathForParams), openshiftVersion, arch)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NmstatectlPathForParams", reflect.TypeOf((*MockImageStore)(nil).NmstatectlPathForParams), version, arch)
+}
+
+// OpenshiftVersionForParams mocks base method.
+func (m *MockImageStore) OpenshiftVersionForParams(version, arch string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenshiftVersionForParams", version, arch)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenshiftVersionForParams indicates an expected call of OpenshiftVersionForParams.
+func (mr *MockImageStoreMockRecorder) OpenshiftVersionForParams(version, arch any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenshiftVersionForParams", reflect.TypeOf((*MockImageStore)(nil).OpenshiftVersionForParams), version, arch)
 }
 
 // PathForParams mocks base method.


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

When implementing MGMT-24783, a part of initrd’s logic was missed.
The version that initrd receives can be an RHCOS version, but we still compare it to the minimum version allowed for nmstate, as if it’s always an openshift version.

When there are multiple OS Images with the same RHCOS version, there's no way to know exactly which openshift version the user originally wanted.
However, going with the highest version is the safest, since it only decides if we include the nmsatectl binary.
So picking a higher version than needed will result in including a binary that's not needed, picking a lower version than needed will result in a missing binary.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->

Closes [MGMT-24907](https://redhat.atlassian.net/browse/MGMT-24907)

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version handling when generating initrd overlays, ensuring nmstate content is included for supported RHCOS and OpenShift version combinations.
  * Requests with unsupported or unresolvable version and architecture combinations now return a clear `400 Bad Request` response instead of proceeding incorrectly.
* **Tests**
  * Added coverage for supported version mappings and nmstatectl inclusion in generated initrd responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->