### PR TITLE
ACM-30180: Add TLS profile support for cluster-wide TLS compliance

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ var Options struct {
 	DataTempDir           string `envconfig:"DATA_TEMP_DIR" default:"/data_temp"`
 	HTTPSKeyFile          string `envconfig:"HTTPS_KEY_FILE"`
 	HTTPSCertFile         string `envconfig:"HTTPS_CERT_FILE"`
+	TLSMinVersion         string `envconfig:"TLS_MIN_VERSION"`
+	TLSCipherSuites       string `envconfig:"TLS_CIPHER_SUITES"`
 
 	// Deprecated - use ASSISTED_SERVICE_API_TRUSTED_CA_FILE instead
 	HTTPSCAFile string `envconfig:"HTTPS_CA_FILE"`
@@ -191,6 +193,7 @@ func main() {
 	http.Handle("/bytoken/", imageHandler)
 	http.Handle("/s390x-initrd-addrsize", imageHandler)
 
+	serverInfo.ApplyTLSProfile(Options.TLSMinVersion, Options.TLSCipherSuites)
 	serverInfo.ListenAndServe()
 	<-stop
 	serverInfo.Shutdown()

--- a/pkg/servers/servers.go
+++ b/pkg/servers/servers.go
@@ -2,12 +2,21 @@ package servers
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 )
+
+var tlsVersions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
 
 type ServerInfo struct {
 	HTTP            *http.Server
@@ -85,6 +94,60 @@ func (s *ServerInfo) Shutdown() bool {
 		}
 	}
 	return true
+}
+
+// ApplyTLSProfile configures the HTTPS server with the given TLS minimum
+// version and cipher suites. The version should be a Go TLS version name
+// (e.g., "VersionTLS12"). Cipher suites should be comma-separated IANA names.
+// If minVersion is empty, no TLS configuration is applied.
+func (s *ServerInfo) ApplyTLSProfile(minVersion, cipherSuites string) {
+	if s.HTTPS == nil || minVersion == "" {
+		return
+	}
+
+	version, ok := tlsVersions[minVersion]
+	if !ok {
+		log.Warnf("Unknown TLS version %q, skipping TLS profile configuration", minVersion)
+		return
+	}
+
+	cfg := &tls.Config{MinVersion: version}
+
+	if version < tls.VersionTLS13 && cipherSuites != "" {
+		var unsupported []string
+		for _, name := range strings.Split(cipherSuites, ",") {
+			name = strings.TrimSpace(name)
+			if id, ok := cipherSuiteID(name); ok {
+				cfg.CipherSuites = append(cfg.CipherSuites, id)
+			} else {
+				unsupported = append(unsupported, name)
+			}
+		}
+		if len(unsupported) > 0 {
+			log.Infof("TLS profile contains cipher suites that Go does not implement, ignoring: %s", strings.Join(unsupported, ", "))
+		}
+	}
+
+	s.HTTPS.TLSConfig = cfg
+	log.Infof("TLS profile applied: MinVersion=%s", minVersion)
+}
+
+// cipherSuiteID resolves an IANA cipher suite name to its Go identifier. Both
+// the secure and the insecure lists are searched, since the Old TLS profile
+// legitimately includes suites that Go classifies as insecure and the cluster
+// profile is the authority on what is allowed.
+func cipherSuiteID(name string) (uint16, bool) {
+	for _, suite := range tls.CipherSuites() {
+		if suite.Name == name {
+			return suite.ID, true
+		}
+	}
+	for _, suite := range tls.InsecureCipherSuites() {
+		if suite.Name == name {
+			return suite.ID, true
+		}
+	}
+	return 0, false
 }
 
 func (s *ServerInfo) httpListen() {


### PR DESCRIPTION
Enable the assisted-image-service to obey the cluster's central TLS security profile. The infrastructure-operator reads the TLS profile from the APIServer resource and passes the minimum TLS version and cipher suites when creating the image-service pod. The image-service applies these settings to its HTTPS server at startup, ensuring it only accepts connections that match the cluster's configured profile.

New environment variables:
- TLS_MIN_VERSION: minimum TLS version (e.g., VersionTLS12)
- TLS_CIPHER_SUITES: comma-separated IANA cipher suite names

When not set, the server uses Go's default TLS settings (unchanged behavior for non-ACM deployments).

## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options for setting the minimum TLS version.
  * Added support for configuring TLS cipher suites for older TLS versions.
  * Invalid TLS version values and unsupported cipher suites are reported in server logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->