### PR TITLE
MGMT-25140: Add a struct for OS Image and correctly check if initrd should include the nmstatectl

### DIFF
--- a/integration_test/images_test.go
+++ b/integration_test/images_test.go
@@ -31,66 +31,66 @@ import (
 )
 
 var (
-	versions = []map[string]string{
+	versions = []imagestore.OSImage{
 		{
-			"openshift_version": "4.17.0-ec.1",
-			"cpu_architecture":  "arm64",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/pre-release/latest/rhcos-live-iso.aarch64.iso",
-			"version":           "arm-latest",
+			OpenshiftVersion: "4.17.0-ec.1",
+			CPUArchitecture:  "arm64",
+			URL:              "https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/pre-release/latest/rhcos-live-iso.aarch64.iso",
+			Version:          "arm-latest",
 		},
 		{
-			"openshift_version": "4.8",
-			"cpu_architecture":  "x86_64",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.8/latest/rhcos-live.x86_64.iso",
-			"version":           "4.8-latest",
+			OpenshiftVersion: "4.8",
+			CPUArchitecture:  "x86_64",
+			URL:              "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.8/latest/rhcos-live.x86_64.iso",
+			Version:          "4.8-latest",
 		},
 		{
-			"openshift_version": "4.10.0-rc.0",
-			"cpu_architecture":  "x86_64",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.10.0-rc.0/rhcos-live.x86_64.iso",
-			"version":           "x86_64-latest",
+			OpenshiftVersion: "4.10.0-rc.0",
+			CPUArchitecture:  "x86_64",
+			URL:              "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.10.0-rc.0/rhcos-live.x86_64.iso",
+			Version:          "x86_64-latest",
 		},
 		{
-			"openshift_version": "4.11",
-			"cpu_architecture":  "x86_64",
-			"url":               "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live.x86_64.iso",
-			"version":           "x86_64-latest",
+			OpenshiftVersion: "4.11",
+			CPUArchitecture:  "x86_64",
+			URL:              "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/x86_64/fedora-coreos-35.20220103.3.0-live.x86_64.iso",
+			Version:          "x86_64-latest",
 		},
 		{
-			"openshift_version": "4.11",
-			"cpu_architecture":  "arm64",
-			"url":               "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live.aarch64.iso",
-			"version":           "arm-latest",
+			OpenshiftVersion: "4.11",
+			CPUArchitecture:  "arm64",
+			URL:              "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20220103.3.0/aarch64/fedora-coreos-35.20220103.3.0-live.aarch64.iso",
+			Version:          "arm-latest",
 		},
 		{
-			"openshift_version": "4.11",
-			"cpu_architecture":  "s390x",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-s390x-live.s390x.iso",
-			"version":           "s390x-latest",
+			OpenshiftVersion: "4.11",
+			CPUArchitecture:  "s390x",
+			URL:              "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-s390x-live.s390x.iso",
+			Version:          "s390x-latest",
 		},
 		{
-			"openshift_version": "4.11",
-			"cpu_architecture":  "ppc64le",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-ppc64le-live.ppc64le.iso",
-			"version":           "ppc64le-latest",
+			OpenshiftVersion: "4.11",
+			CPUArchitecture:  "ppc64le",
+			URL:              "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-ppc64le-live.ppc64le.iso",
+			Version:          "ppc64le-latest",
 		},
 		{
-			"openshift_version": "4.13",
-			"cpu_architecture":  "x86_64",
-			"url":               "https://okd-scos.s3.amazonaws.com/okd-scos/builds/413.9.202302280609-0/x86_64/scos-413.9.202302280609-0-live.x86_64.iso",
-			"version":           "x86_64-latest",
+			OpenshiftVersion: "4.13",
+			CPUArchitecture:  "x86_64",
+			URL:              "https://okd-scos.s3.amazonaws.com/okd-scos/builds/413.9.202302280609-0/x86_64/scos-413.9.202302280609-0-live.x86_64.iso",
+			Version:          "x86_64-latest",
 		},
 		{
-			"openshift_version": "4.18",
-			"cpu_architecture":  "s390x",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.18/4.18.1/rhcos-4.18.1-s390x-live.s390x.iso",
-			"version":           "s390x-418",
+			OpenshiftVersion: "4.18",
+			CPUArchitecture:  "s390x",
+			URL:              "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.18/4.18.1/rhcos-4.18.1-s390x-live.s390x.iso",
+			Version:          "s390x-418",
 		},
 		{
-			"openshift_version": "4.18",
-			"cpu_architecture":  "x86_64",
-			"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.18/4.18.1/rhcos-4.18.1-x86_64-live.x86_64.iso",
-			"version":           "x86_64-418",
+			OpenshiftVersion: "4.18",
+			CPUArchitecture:  "x86_64",
+			URL:              "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.18/4.18.1/rhcos-4.18.1-x86_64-live.x86_64.iso",
+			Version:          "x86_64-418",
 		},
 	}
 
@@ -221,8 +221,8 @@ var _ = Describe("Image integration tests", func() {
 			for i := range versions {
 				version := versions[i]
 
-				It("returns a properly generated "+tc.name+" iso image "+version["version"], func() {
-					if version["cpu_architecture"] == "s390x" {
+				It("returns a properly generated "+tc.name+" iso image "+version.Version, func() {
+					if version.CPUArchitecture == "s390x" {
 						if tc.imageType == imagestore.ImageTypeMinimal {
 							Skip("minimal ISO is not supported for s390x architecture")
 						}
@@ -232,12 +232,12 @@ var _ = Describe("Image integration tests", func() {
 					}
 
 					By("getting an iso")
-					path := fmt.Sprintf("/byid/%s/%s/%s/%s", imageID, version["openshift_version"], version["cpu_architecture"], tc.fileName)
+					path := fmt.Sprintf("/byid/%s/%s/%s/%s", imageID, version.OpenshiftVersion, version.CPUArchitecture, tc.fileName)
 					resp, err := imageClient.Get(imageServer.URL + path)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-					isoFile, err := os.CreateTemp("", fmt.Sprintf("imageTest-%s-%s.%s.iso", version["openshift_version"], tc.name, version["cpu_architecture"]))
+					isoFile, err := os.CreateTemp("", fmt.Sprintf("imageTest-%s-%s.%s.iso", version.OpenshiftVersion, tc.name, version.CPUArchitecture))
 					Expect(err).NotTo(HaveOccurred())
 					_, err = io.Copy(isoFile, resp.Body)
 					Expect(err).NotTo(HaveOccurred())
@@ -330,8 +330,8 @@ var _ = Describe("Image integration tests", func() {
 			for i := range versions {
 				version := versions[i]
 
-				It("includes nmstate for "+version["openshift_version"]+" "+version["cpu_architecture"], func() {
-					ok, err := common.VersionGreaterOrEqual(version["openshift_version"], isoeditor.MinimalVersionForNmstatectl)
+				It("includes nmstate for "+version.OpenshiftVersion+" "+version.CPUArchitecture, func() {
+					ok, err := common.VersionGreaterOrEqual(version.OpenshiftVersion, isoeditor.MinimalVersionForNmstatectl)
 					Expect(err).NotTo(HaveOccurred())
 
 					if len(tc.expectedRamdisk) <= 0 || !ok {
@@ -339,7 +339,7 @@ var _ = Describe("Image integration tests", func() {
 					}
 
 					path := fmt.Sprintf("/images/%s/pxe-initrd?version=%s&arch=%s",
-						imageID, version["openshift_version"], version["cpu_architecture"])
+						imageID, version.OpenshiftVersion, version.CPUArchitecture)
 					resp2, err := imageClient.Get(imageServer.URL + path)
 					Expect(err).NotTo(HaveOccurred())
 					defer resp2.Body.Close()
@@ -348,8 +348,9 @@ var _ = Describe("Image integration tests", func() {
 					initrdBytes, err := io.ReadAll(resp2.Body)
 					Expect(err).NotTo(HaveOccurred())
 
-					nmPath, err := imageStore.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+					nmPath, exists, err := imageStore.NmstatectlPathForParams(version.OpenshiftVersion, version.CPUArchitecture)
 					Expect(err).NotTo(HaveOccurred())
+					Expect(exists).To(BeTrue())
 					nmBytes, err := os.ReadFile(nmPath)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -390,7 +391,7 @@ func TestIntegration(t *testing.T) {
 	RunSpecs(t, "image building tests")
 }
 
-func ignitionPayloadReader(fs filesystem.FileSystem, version map[string]string) (io.ReadCloser, error) {
+func ignitionPayloadReader(fs filesystem.FileSystem, version imagestore.OSImage) (io.ReadCloser, error) {
 	ignInfoFile, err := fs.OpenFile("/coreos/igninfo.json", os.O_RDONLY)
 	if err == nil {
 		defer ignInfoFile.Close()

--- a/internal/handlers/initrd.go
+++ b/internal/handlers/initrd.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/openshift/assisted-image-service/internal/common"
-
 	"github.com/go-chi/chi/v5"
 	log "github.com/sirupsen/logrus"
 
@@ -92,16 +90,12 @@ func initrdOverlayReader(imageStore imagestore.ImageStore, client *AssistedServi
 			return nil, "", http.StatusInternalServerError, fmt.Errorf("failed to create append reader for initrd: %v", err)
 		}
 
-		versionOK, err := common.VersionGreaterOrEqual(version, isoeditor.MinimalVersionForNmstatectl)
+		nmstatectlPath, exists, err := imageStore.NmstatectlPathForParams(version, arch)
 		if err != nil {
 			return nil, "", http.StatusInternalServerError, err
 		}
 
-		if versionOK {
-			nmstatectlPath, err := imageStore.NmstatectlPathForParams(version, arch)
-			if err != nil {
-				return nil, "", http.StatusInternalServerError, err
-			}
+		if exists {
 			nmstateImgContent, err := os.Open(nmstatectlPath) //nolint:gosec // G703 false positive, path is checked inside NmstatectlPathForParams
 			if err != nil {
 				return nil, "", http.StatusInternalServerError, fmt.Errorf("failed to read nmstate img: %v", err)

--- a/internal/handlers/initrd_addrsize_test.go
+++ b/internal/handlers/initrd_addrsize_test.go
@@ -134,7 +134,7 @@ var _ = Describe("ServeHTTP", func() {
 				ghttp.RespondWith(http.StatusOK, minimalInitrdContent),
 			),
 		)
-		mockImageStore.EXPECT().NmstatectlPathForParams("4.18", "s390x").Return(nmstatectlPathForCaching, nil).AnyTimes()
+		mockImageStore.EXPECT().NmstatectlPathForParams("4.18", "s390x").Return(nmstatectlPathForCaching, true, nil).AnyTimes()
 		resp, err := client.Get(fmt.Sprintf("%s/images/%s/s390x-initrd-addrsize?version=4.18", server.URL, imageID))
 		Expect(err).NotTo(HaveOccurred())
 		expectSuccessfulResponse(resp, initrdAddrsizeWithNmstatectl)

--- a/internal/handlers/initrd_test.go
+++ b/internal/handlers/initrd_test.go
@@ -12,8 +12,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-	"github.com/openshift/assisted-image-service/pkg/imagestore"
 	"go.uber.org/mock/gomock"
+
+	"github.com/openshift/assisted-image-service/pkg/imagestore"
 )
 
 var _ = Describe("ServeHTTP", func() {
@@ -125,6 +126,7 @@ var _ = Describe("ServeHTTP", func() {
 				ghttp.RespondWith(http.StatusOK, minimalInitrdContent),
 			),
 		)
+		mockImageStore.EXPECT().NmstatectlPathForParams("4.9", "x86_64").Return(nmstatectlPathForCaching, false, nil).AnyTimes()
 		resp, err := client.Get(fmt.Sprintf("%s/images/%s/pxe-initrd?version=4.9&arch=x86_64", server.URL, imageID))
 		Expect(err).NotTo(HaveOccurred())
 		expectSuccessfulResponse(resp, append(append(initrdContent, ignitionArchiveBytes...), minimalInitrdContent...))
@@ -203,7 +205,7 @@ var _ = Describe("ServeHTTP", func() {
 				ghttp.RespondWith(http.StatusOK, minimalInitrdContent),
 			),
 		)
-		mockImageStore.EXPECT().NmstatectlPathForParams("4.18", "x86_64").Return(nmstatectlPathForCaching, nil).AnyTimes()
+		mockImageStore.EXPECT().NmstatectlPathForParams("4.18", "x86_64").Return(nmstatectlPathForCaching, true, nil).AnyTimes()
 		resp, err := client.Get(fmt.Sprintf("%s/images/%s/pxe-initrd?version=4.18&arch=x86_64", server.URL, imageID))
 		Expect(err).NotTo(HaveOccurred())
 		expectSuccessfulResponse(resp, append(append(append(initrdContent, ignitionArchiveBytes...), minimalInitrdContent...), nmstatectlContent...))

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func main() {
 		versionsJSON = Options.RHCOSVersions
 	}
 
-	var versions []map[string]string
+	var versions []imagestore.OSImage
 	if versionsJSON == "" {
 		versions = imagestore.DefaultVersions
 	} else {

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -23,48 +23,61 @@ import (
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 )
 
-var DefaultVersions = []map[string]string{
+// OSImage describes an OS image entry from OS_IMAGES / RHCOS_VERSIONS JSON.
+// Field names and types match the assisted-service os-image schema so the shared
+// catalog JSON (including boolean default_os_stream) unmarshals correctly.
+type OSImage struct {
+	OpenshiftVersion string `json:"openshift_version"`
+	CPUArchitecture  string `json:"cpu_architecture"`
+	URL              string `json:"url"`
+	Version          string `json:"version"`
+	Type             string `json:"type,omitempty"`
+	OsStream         string `json:"os_stream,omitempty"`
+	DefaultOsStream  *bool  `json:"default_os_stream,omitempty"`
+}
+
+var DefaultVersions = []OSImage{
 	{
-		"openshift_version": "4.8",
-		"cpu_architecture":  "x86_64",
-		"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso",
-		"version":           "48.84.202109241901-0",
+		OpenshiftVersion: "4.8",
+		CPUArchitecture:  "x86_64",
+		URL:              "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso",
+		Version:          "48.84.202109241901-0",
 	},
 	{
-		"openshift_version": "4.9",
-		"cpu_architecture":  "x86_64",
-		"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-x86_64-live.x86_64.iso",
-		"version":           "49.84.202110081407-0",
+		OpenshiftVersion: "4.9",
+		CPUArchitecture:  "x86_64",
+		URL:              "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-x86_64-live.x86_64.iso",
+		Version:          "49.84.202110081407-0",
 	},
 	{
-		"openshift_version": "4.9",
-		"cpu_architecture":  "arm64",
-		"url":               "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-aarch64-live.aarch64.iso",
-		"version":           "49.84.202110080947-0",
+		OpenshiftVersion: "4.9",
+		CPUArchitecture:  "arm64",
+		URL:              "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-aarch64-live.aarch64.iso",
+		Version:          "49.84.202110080947-0",
 	},
 	{
-		"openshift_version": "4.10",
-		"cpu_architecture":  "x86_64",
-		"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-x86_64-live.x86_64.iso",
-		"version":           "410.84.202201251210-0",
+		OpenshiftVersion: "4.10",
+		CPUArchitecture:  "x86_64",
+		URL:              "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-x86_64-live.x86_64.iso",
+		Version:          "410.84.202201251210-0",
 	},
 	{
-		"openshift_version": "4.10",
-		"cpu_architecture":  "arm64",
-		"url":               "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-aarch64-live.aarch64.iso",
-		"version":           "410.84.202201251210-0",
+		OpenshiftVersion: "4.10",
+		CPUArchitecture:  "arm64",
+		URL:              "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-aarch64-live.aarch64.iso",
+		Version:          "410.84.202201251210-0",
 	},
 	{
-		"openshift_version": "4.11",
-		"cpu_architecture":  "x86_64",
-		"url":               "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.11.0-0.nightly-2022-04-16-163450/rhcos-4.11.0-0.nightly-2022-04-16-163450-x86_64-live.x86_64.iso",
-		"version":           "411.85.202203242008-0",
+		OpenshiftVersion: "4.11",
+		CPUArchitecture:  "x86_64",
+		URL:              "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/4.11.0-0.nightly-2022-04-16-163450/rhcos-4.11.0-0.nightly-2022-04-16-163450-x86_64-live.x86_64.iso",
+		Version:          "411.85.202203242008-0",
 	},
 	{
-		"openshift_version": "4.11",
-		"cpu_architecture":  "arm64",
-		"url":               "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/4.11.0-0.nightly-arm64-2022-04-19-171931/rhcos-4.11.0-0.nightly-arm64-2022-04-19-171931-aarch64-live.aarch64.iso",
-		"version":           "411.86.202204190940-0",
+		OpenshiftVersion: "4.11",
+		CPUArchitecture:  "arm64",
+		URL:              "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/4.11.0-0.nightly-arm64-2022-04-19-171931/rhcos-4.11.0-0.nightly-arm64-2022-04-19-171931-aarch64-live.aarch64.iso",
+		Version:          "411.86.202204190940-0",
 	},
 }
 
@@ -73,11 +86,11 @@ type ImageStore interface {
 	Populate(ctx context.Context) error
 	PathForParams(imageType, version, arch string) string
 	HaveVersion(version, arch string) bool
-	NmstatectlPathForParams(openshiftVersion, arch string) (string, error)
+	NmstatectlPathForParams(openshiftVersion, arch string) (string, bool, error)
 }
 
 type rhcosStore struct {
-	versions                      []map[string]string
+	versions                      []OSImage
 	isoEditor                     isoeditor.Editor
 	dataDir                       string
 	httpClient                    *http.Client
@@ -100,7 +113,7 @@ const (
 	minKernelSize = 5 * 1024 * 1024
 )
 
-func NewImageStore(ed isoeditor.Editor, dataDir, imageServiceBaseURL string, insecureSkipVerify bool, versions []map[string]string,
+func NewImageStore(ed isoeditor.Editor, dataDir, imageServiceBaseURL string, insecureSkipVerify bool, versions []OSImage,
 	osImageDownloadTrustedCAFile string, osImageDownloadHeadersMap map[string]string, osImageDownloadQueryParamsMap map[string]string, nmstateHandler isoeditor.NmstateHandler) (ImageStore, error) {
 	if err := validateVersions(versions); err != nil {
 		return nil, err
@@ -147,22 +160,22 @@ func NewImageStore(ed isoeditor.Editor, dataDir, imageServiceBaseURL string, ins
 	}, nil
 }
 
-func validateVersions(versions []map[string]string) error {
+func validateVersions(versions []OSImage) error {
 	if len(versions) == 0 {
 		return fmt.Errorf("invalid versions: must not be empty")
 	}
 	for _, entry := range versions {
 		missingKeyFmt := "invalid version entry %+v: missing %s key"
-		if _, ok := entry["openshift_version"]; !ok {
+		if entry.OpenshiftVersion == "" {
 			return fmt.Errorf(missingKeyFmt, entry, "openshift_version")
 		}
-		if _, ok := entry["cpu_architecture"]; !ok {
+		if entry.CPUArchitecture == "" {
 			return fmt.Errorf(missingKeyFmt, entry, "cpu_architecture")
 		}
-		if _, ok := entry["url"]; !ok {
+		if entry.URL == "" {
 			return fmt.Errorf(missingKeyFmt, entry, "url")
 		}
-		if _, ok := entry["version"]; !ok {
+		if entry.Version == "" {
 			return fmt.Errorf(missingKeyFmt, entry, "version")
 		}
 	}
@@ -286,17 +299,17 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 	for i := range versions {
 		imageInfo := versions[i]
 		errs.Go(func() error {
-			imageVersion := imageInfo["version"]
-			arch := imageInfo["cpu_architecture"]
+			imageVersion := imageInfo.Version
+			arch := imageInfo.CPUArchitecture
 
-			imageType, err := s.getImageType(imageInfo)
+			imageType, err := getImageType(imageInfo)
 			if err != nil {
 				return fmt.Errorf("failed to get image type: %v", err)
 			}
 
 			fullPath := filepath.Join(s.dataDir, isoFileName(imageType, imageVersion, arch))
 			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-				url := imageInfo["url"]
+				url := imageInfo.URL
 				log.Infof("Downloading iso from %s to %s", url, fullPath)
 
 				err = s.downloadURLToFile(url, fullPath)
@@ -336,13 +349,13 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 
 	for i := range versions {
 		imageInfo := versions[i]
-		openshiftVersion := imageInfo["openshift_version"]
-		imageVersion := imageInfo["version"]
-		arch := imageInfo["cpu_architecture"]
+		openshiftVersion := imageInfo.OpenshiftVersion
+		imageVersion := imageInfo.Version
+		arch := imageInfo.CPUArchitecture
 
 		// Don't attempt to create a minimal ISO for disconnected-interactive-iso
 		// It's meant to be a full ISO with embedded ignition
-		imageType, err := s.getImageType(imageInfo)
+		imageType, err := getImageType(imageInfo)
 		if err != nil {
 			return fmt.Errorf("failed to get image type: %v", err)
 		}
@@ -370,13 +383,13 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 				return fmt.Errorf("failed to build rootfs URL: %v", err)
 			}
 
-			nmstatectlPath, err := s.NmstatectlPathForParams(imageVersion, arch)
+			nmstatectlPath, _, err := s.NmstatectlPathForParams(imageVersion, arch)
 			if err != nil {
 				return err
 			}
 			err = s.isoEditor.CreateMinimalISOTemplate(fullPath, rootfsURL, arch, minimalPath, openshiftVersion, nmstatectlPath)
 			if err != nil {
-				return fmt.Errorf("failed to create minimal iso template for version %s: %v", imageInfo, err)
+				return fmt.Errorf("failed to create minimal iso template for version %+v: %v", imageInfo, err)
 			}
 
 			log.Infof("Finished creating minimal iso for %s-%s", imageVersion, arch)
@@ -389,73 +402,72 @@ func (s *rhcosStore) Populate(ctx context.Context) error {
 // deduplicateVersions keeps a single entry per RHCOS version, CPU architecture pair and image type.
 // When multiple pairs share the same RHCOS image, the entry with the highest openshift_version is kept.
 // It's important to keep that entry because the openshift_version is used to decide if we want the nmstatectl for that entry.
-func deduplicateVersions(versions []map[string]string) []map[string]string {
-	m := make(map[string]map[string]string, len(versions))
+func deduplicateVersions(versions []OSImage) []OSImage {
+	m := make(map[string]OSImage, len(versions))
 
 	for _, entry := range versions {
-		imageType := entry["type"]
+		imageType := entry.Type
 		if imageType == "" {
 			imageType = ImageTypeFull
 		}
-		key := entry["version"] + "@" + entry["cpu_architecture"] + "@" + imageType
+		key := entry.Version + "@" + entry.CPUArchitecture + "@" + imageType
 		existing, ok := m[key]
 		if !ok {
 			m[key] = entry
 			continue
 		}
-		greater, err := common.VersionGreaterOrEqual(entry["openshift_version"], existing["openshift_version"])
+		greater, err := common.VersionGreaterOrEqual(entry.OpenshiftVersion, existing.OpenshiftVersion)
 		if err != nil {
 			log.Debugf(
 				"Couldn't check if OS image entry for key %s with openshift_version %s has a greater openshift version, keeping %s, error: %v",
-				key, entry["openshift_version"], existing["openshift_version"], err,
+				key, entry.OpenshiftVersion, existing.OpenshiftVersion, err,
 			)
 			continue
 		}
 		if greater {
 			log.Debugf(
 				"Replacing duplicate OS image entry for key %s with openshift_version %s (was %s)",
-				key, entry["openshift_version"], existing["openshift_version"],
+				key, entry.OpenshiftVersion, existing.OpenshiftVersion,
 			)
 			m[key] = entry
 		} else {
 			log.Debugf(
 				"Skipping duplicate OS image entry for key %s (openshift_version %s, keeping %s)",
-				key, entry["openshift_version"], existing["openshift_version"],
+				key, entry.OpenshiftVersion, existing.OpenshiftVersion,
 			)
 		}
 	}
 
-	result := make([]map[string]string, 0, len(m))
+	result := make([]OSImage, 0, len(m))
 	for _, entry := range m {
 		result = append(result, entry)
 	}
 	return result
 }
 
-func (*rhcosStore) getImageType(imageInfo map[string]string) (string, error) {
+func getImageType(imageInfo OSImage) (string, error) {
 	validTypes := map[string]bool{
 		ImageTypeFull:            true,
 		ImageTypeDisconnectedIso: true,
 	}
 
-	imageType, ok := imageInfo["type"]
-	if !ok {
+	if imageInfo.Type == "" {
 		return ImageTypeFull, nil
 	}
 
-	if !validTypes[imageType] {
-		return "", fmt.Errorf("invalid image type: %s", imageType)
+	if !validTypes[imageInfo.Type] {
+		return "", fmt.Errorf("invalid image type: %s", imageInfo.Type)
 	}
 
-	return imageType, nil
+	return imageInfo.Type, nil
 }
 
 // extractAndCacheNmstatectl extracts nmstatectl from the rootfs and caches it for later use
 // This ensures nmstatectl is available for both minimal ISO creation and PXE provisioning
-func (s *rhcosStore) extractAndCacheNmstatectl(imageInfo map[string]string) error {
-	openshiftVersion := imageInfo["openshift_version"]
-	imageVersion := imageInfo["version"]
-	arch := imageInfo["cpu_architecture"]
+func (s *rhcosStore) extractAndCacheNmstatectl(imageInfo OSImage) error {
+	openshiftVersion := imageInfo.OpenshiftVersion
+	imageVersion := imageInfo.Version
+	arch := imageInfo.CPUArchitecture
 
 	// Check if version supports nmstatectl
 	versionOK, err := common.VersionGreaterOrEqual(openshiftVersion, isoeditor.MinimalVersionForNmstatectl)
@@ -467,13 +479,12 @@ func (s *rhcosStore) extractAndCacheNmstatectl(imageInfo map[string]string) erro
 		return nil
 	}
 
-	nmstatectlPath, err := s.NmstatectlPathForParams(imageVersion, arch)
+	nmstatectlPath, exists, err := s.NmstatectlPathForParams(imageVersion, arch)
 	if err != nil {
 		return err
 	}
 
-	// Check if nmstatectl is already cached
-	if _, err = os.Stat(nmstatectlPath); err == nil {
+	if exists {
 		log.Debugf("nmstatectl already cached for %s-%s", imageVersion, arch)
 		return nil
 	}
@@ -530,20 +541,22 @@ func (s *rhcosStore) extractAndCacheNmstatectl(imageInfo map[string]string) erro
 	return nil
 }
 
-func (s *rhcosStore) findVersionEntry(versionKey, arch string) map[string]string {
-	for _, entry := range s.versions {
-		if entry["cpu_architecture"] != arch {
+func (s *rhcosStore) findVersionEntry(versionKey, arch string) *OSImage {
+	for i := range s.versions {
+		entry := &s.versions[i]
+		if entry.CPUArchitecture != arch {
 			continue
 		}
-		if entry["version"] == versionKey {
+		if entry.Version == versionKey {
 			return entry
 		}
 	}
-	for _, entry := range s.versions {
-		if entry["cpu_architecture"] != arch {
+	for i := range s.versions {
+		entry := &s.versions[i]
+		if entry.CPUArchitecture != arch {
 			continue
 		}
-		if entry["openshift_version"] == versionKey {
+		if entry.OpenshiftVersion == versionKey {
 			return entry
 		}
 	}
@@ -554,7 +567,7 @@ func (s *rhcosStore) PathForParams(imageType, versionKey, arch string) string {
 	rhcosVersion := versionKey
 	entry := s.findVersionEntry(versionKey, arch)
 	if entry != nil {
-		rhcosVersion = entry["version"]
+		rhcosVersion = entry.Version
 	}
 	return filepath.Join(s.dataDir, isoFileName(imageType, rhcosVersion, arch))
 }
@@ -585,9 +598,9 @@ func (s *rhcosStore) cleanDataDir() error {
 	var expectedFiles []string
 	for _, version := range s.versions {
 		// Only add full isos here as we want to regenerate the minimal image on each deploy
-		expectedFiles = append(expectedFiles, isoFileName(ImageTypeFull, version["version"], version["cpu_architecture"]))
+		expectedFiles = append(expectedFiles, isoFileName(ImageTypeFull, version.Version, version.CPUArchitecture))
 		// Keep nmstatectl cached files for all architectures (including s390x)
-		expectedFiles = append(expectedFiles, nmstatectlFileName(version["version"], version["cpu_architecture"]))
+		expectedFiles = append(expectedFiles, nmstatectlFileName(version.Version, version.CPUArchitecture))
 	}
 
 	dataDirFiles, err := os.ReadDir(s.dataDir)
@@ -612,20 +625,28 @@ func (s *rhcosStore) HaveVersion(version, arch string) bool {
 	return s.findVersionEntry(version, arch) != nil
 }
 
-func (s *rhcosStore) NmstatectlPathForParams(versionKey, arch string) (string, error) {
+func (s *rhcosStore) NmstatectlPathForParams(versionKey, arch string) (string, bool, error) {
 	rhcosVersion := versionKey
 	entry := s.findVersionEntry(versionKey, arch)
 	if entry != nil {
-		rhcosVersion = entry["version"]
+		rhcosVersion = entry.Version
 	}
 	nmstatectlPath := filepath.Join(s.dataDir, nmstatectlFileName(rhcosVersion, arch))
 
 	// Safety check: ensures nmstatectlPath stays within the expected dataDir,
 	// preventing crafted inputs from escaping the intended directory
 	if filepath.Dir(nmstatectlPath) != s.dataDir {
-		return "", fmt.Errorf("invalid nmstatectl path: %s", nmstatectlPath)
+		return "", false, fmt.Errorf("invalid nmstatectl path: %s", nmstatectlPath)
 	}
-	return nmstatectlPath, nil
+
+	_, err := os.Stat(nmstatectlPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nmstatectlPath, false, nil
+		}
+		return nmstatectlPath, false, err
+	}
+	return nmstatectlPath, true, nil
 }
 
 func nmstatectlFileName(version, arch string) string {

--- a/pkg/imagestore/imagestore_test.go
+++ b/pkg/imagestore/imagestore_test.go
@@ -140,10 +140,10 @@ var _ = Context("with a data directory configured", func() {
 				mockNmstateHandler *isoeditor.MockNmstateHandler
 				isoDir             string
 				validVolumeID      = "rhcos-411.86.202210041459-0"
-				version            = map[string]string{
-					"openshift_version": "4.8",
-					"cpu_architecture":  "x86_64",
-					"version":           "48.84.202109241901-0",
+				version            = OSImage{
+					OpenshiftVersion: "4.8",
+					CPUArchitecture:  "x86_64",
+					Version:          "48.84.202109241901-0",
 				}
 			)
 
@@ -180,14 +180,14 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
 					),
 				)
-				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, caCertFileName, osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				version.URL = ts.URL() + "/some.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, caCertFileName, osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["version"])
-				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				rootfs := fmt.Sprintf(rootfsURL, version.Version)
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(version.OpenshiftVersion, version.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version.OpenshiftVersion, nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
@@ -224,15 +224,15 @@ var _ = Context("with a data directory configured", func() {
 				mockNmstateHandler *isoeditor.MockNmstateHandler
 				isoDir             string
 				validVolumeID      = "rhcos-411.86.202210041459-0"
-				version            = map[string]string{
-					"openshift_version": "4.8",
-					"cpu_architecture":  "x86_64",
-					"version":           "48.84.202109241901-0",
+				version            = OSImage{
+					OpenshiftVersion: "4.8",
+					CPUArchitecture:  "x86_64",
+					Version:          "48.84.202109241901-0",
 				}
-				versionPatch = map[string]string{
-					"openshift_version": "4.8.1",
-					"cpu_architecture":  "x86_64",
-					"version":           "48.84.202109241901-0",
+				versionPatch = OSImage{
+					OpenshiftVersion: "4.8.1",
+					CPUArchitecture:  "x86_64",
+					Version:          "48.84.202109241901-0",
 				}
 			)
 
@@ -278,14 +278,14 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
 					),
 				)
-				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				version.URL = ts.URL() + "/some.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["version"])
-				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				rootfs := fmt.Sprintf(rootfsURL, version.Version)
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(version.OpenshiftVersion, version.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version.OpenshiftVersion, nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
@@ -307,14 +307,14 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
 					),
 				)
-				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				version.URL = ts.URL() + "/some.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["version"])
-				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				rootfs := fmt.Sprintf(rootfsURL, version.Version)
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(version.OpenshiftVersion, version.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version.OpenshiftVersion, nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
@@ -330,14 +330,14 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
 					),
 				)
-				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				version.URL = ts.URL() + "/some.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["version"])
-				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				rootfs := fmt.Sprintf(rootfsURL, version.Version)
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(version.OpenshiftVersion, version.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version.OpenshiftVersion, nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
@@ -352,8 +352,8 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusInternalServerError, "server error"),
 					),
 				)
-				version["url"] = ts.URL() + "/fail.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				version.URL = ts.URL() + "/fail.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(is.Populate(ctx)).NotTo(Succeed())
@@ -367,8 +367,8 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
 					),
 				)
-				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				version.URL = ts.URL() + "/some.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(is.Populate(ctx)).NotTo(Succeed())
@@ -384,14 +384,14 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, "someisocontenthere"),
 					),
 				)
-				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				version.URL = ts.URL() + "/some.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["version"])
-				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				rootfs := fmt.Sprintf(rootfsURL, version.Version)
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(version.OpenshiftVersion, version.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(fmt.Errorf("minimal iso creation failed"))
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version.OpenshiftVersion, nmstatectlPath).Return(fmt.Errorf("minimal iso creation failed"))
 				Expect(is.Populate(ctx)).NotTo(Succeed())
 			})
 
@@ -402,21 +402,21 @@ var _ = Context("with a data directory configured", func() {
 						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { Fail("endpoint should not be queried") }),
 					),
 				)
-				version["url"] = ts.URL() + "/dontcallthis.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				version.URL = ts.URL() + "/dontcallthis.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(os.WriteFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"), []byte("moreisocontent"), 0600)).To(Succeed())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["version"])
-				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				rootfs := fmt.Sprintf(rootfsURL, version.Version)
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(version.OpenshiftVersion, version.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version.OpenshiftVersion, nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 			})
 
 			It("recreates the minimal iso even when it's already present", func() {
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				fullPath := filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso")
@@ -425,10 +425,10 @@ var _ = Context("with a data directory configured", func() {
 				minimalPath := filepath.Join(dataDir, "rhcos-minimal-iso-48.84.202109241901-0-x86_64.iso")
 				Expect(os.WriteFile(minimalPath, []byte("minimalisocontent"), 0600)).To(Succeed())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["version"])
-				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				rootfs := fmt.Sprintf(rootfsURL, version.Version)
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(version.OpenshiftVersion, version.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
-				mockEditor.EXPECT().CreateMinimalISOTemplate(fullPath, rootfs, "x86_64", minimalPath, version["openshift_version"], nmstatectlPath).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(fullPath, rootfs, "x86_64", minimalPath, version.OpenshiftVersion, nmstatectlPath).Return(nil)
 
 				Expect(is.Populate(ctx)).To(Succeed())
 			})
@@ -441,14 +441,14 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
 					),
 				)
-				versionPatch["url"] = ts.URL() + "/somepatchversion.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{versionPatch}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				versionPatch.URL = ts.URL() + "/somepatchversion.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{versionPatch}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, versionPatch["version"])
-				nmstatectlPath, err := is.NmstatectlPathForParams(versionPatch["openshift_version"], versionPatch["cpu_architecture"])
+				rootfs := fmt.Sprintf(rootfsURL, versionPatch.Version)
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(versionPatch.OpenshiftVersion, versionPatch.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), versionPatch["openshift_version"], nmstatectlPath).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), versionPatch.OpenshiftVersion, nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				content, err := os.ReadFile(filepath.Join(dataDir, "rhcos-full-iso-48.84.202109241901-0-x86_64.iso"))
@@ -466,14 +466,14 @@ var _ = Context("with a data directory configured", func() {
 							ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
 						),
 					)
-					versionPatch["url"] = ts.URL() + "/somepatchversion.iso"
-					is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{versionPatch}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+					versionPatch.URL = ts.URL() + "/somepatchversion.iso"
+					is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{versionPatch}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 					Expect(err).NotTo(HaveOccurred())
 
-					rootfs := fmt.Sprintf(rootfsURL, versionPatch["version"])
-					nmstatectlPath, err := is.NmstatectlPathForParams(versionPatch["openshift_version"], versionPatch["cpu_architecture"])
+					rootfs := fmt.Sprintf(rootfsURL, versionPatch.Version)
+					nmstatectlPath, _, err := is.NmstatectlPathForParams(versionPatch.OpenshiftVersion, versionPatch.CPUArchitecture)
 					Expect(err).NotTo(HaveOccurred())
-					mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), versionPatch["openshift_version"], nmstatectlPath).Return(nil)
+					mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), versionPatch.OpenshiftVersion, nmstatectlPath).Return(nil)
 					Expect(is.Populate(ctx)).To(Succeed())
 				}
 			})
@@ -486,8 +486,8 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
 					),
 				)
-				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				version.URL = ts.URL() + "/some.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = is.Populate(ctx)
@@ -509,14 +509,14 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
 					),
 				)
-				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				version.URL = ts.URL() + "/some.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				rootfs := fmt.Sprintf(rootfsURL, version["version"])
-				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				rootfs := fmt.Sprintf(rootfsURL, version.Version)
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(version.OpenshiftVersion, version.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version["openshift_version"], nmstatectlPath).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), version.OpenshiftVersion, nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).To(Succeed())
 
 				_, err = os.Stat(oldISOPath)
@@ -530,8 +530,8 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, "someisocontenthere", http.Header{"Content-Length": []string{"1"}}),
 					),
 				)
-				version["url"] = ts.URL() + "/some.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				version.URL = ts.URL() + "/some.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = is.Populate(ctx)
@@ -543,9 +543,9 @@ var _ = Context("with a data directory configured", func() {
 			})
 
 			It("fails when imageServiceBaseURL is not set", func() {
-				is, err := NewImageStore(mockEditor, dataDir, "", false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				is, err := NewImageStore(mockEditor, dataDir, "", false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
-				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(version.OpenshiftVersion, version.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), "", "x86_64", gomock.Any(), gomock.Any(), nmstatectlPath).Return(nil)
 				Expect(is.Populate(ctx)).NotTo(Succeed())
@@ -559,13 +559,13 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
 					),
 				)
-				version["url"] = ts.URL() + "/some.iso"
+				version.URL = ts.URL() + "/some.iso"
 				baseURL := ":"
-				is, err := NewImageStore(mockEditor, dataDir, baseURL, false, []map[string]string{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				is, err := NewImageStore(mockEditor, dataDir, baseURL, false, []OSImage{version}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).ToNot(HaveOccurred())
 
-				rootfs := fmt.Sprintf("https://images.example.com/api/assisted-images/boot-artifacts/rootfs?arch=x86_64&version=%s", version["version"])
-				nmstatectlPath, err := is.NmstatectlPathForParams(version["openshift_version"], version["cpu_architecture"])
+				rootfs := fmt.Sprintf("https://images.example.com/api/assisted-images/boot-artifacts/rootfs?arch=x86_64&version=%s", version.Version)
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(version.OpenshiftVersion, version.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
 				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), rootfs, "x86_64", gomock.Any(), gomock.Any(), nmstatectlPath).Return(nil)
 				err = is.Populate(ctx)
@@ -573,11 +573,11 @@ var _ = Context("with a data directory configured", func() {
 				Expect(err.Error()).To(Equal("failed to build rootfs URL: parse \":\": missing protocol scheme"))
 			})
 			It("happy flow for s390x architecture with cached nmstatectl", func() {
-				s390xVersion := map[string]string{
-					"openshift_version": "4.18",
-					"cpu_architecture":  "s390x",
-					"version":           "418.92.202403212258-0",
-					"url":               ts.URL() + "/s390x.iso",
+				s390xVersion := OSImage{
+					OpenshiftVersion: "4.18",
+					CPUArchitecture:  "s390x",
+					Version:          "418.92.202403212258-0",
+					URL:              ts.URL() + "/s390x.iso",
 				}
 
 				// Provide valid ISO response
@@ -589,12 +589,13 @@ var _ = Context("with a data directory configured", func() {
 					),
 				)
 
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{s390xVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{s390xVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Pre-create the cached nmstatectl file to avoid extraction
-				nmstatectlPath, err := is.NmstatectlPathForParams(s390xVersion["openshift_version"], s390xVersion["cpu_architecture"])
+				nmstatectlPath, exists, err := is.NmstatectlPathForParams(s390xVersion.OpenshiftVersion, s390xVersion.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(exists).To(BeFalse())
 				Expect(os.WriteFile(nmstatectlPath, []byte("cached-nmstatectl"), 0755)).To(Succeed()) //nolint:gosec
 
 				// If arch is s390x, CreateMinimalISOTemplate must not be called.
@@ -606,11 +607,11 @@ var _ = Context("with a data directory configured", func() {
 			})
 			DescribeTable("happy flow for all architectures  except s390x, with a cached nmstatectl",
 				func(arch string) {
-					archVersion := map[string]string{
-						"openshift_version": "4.18",
-						"cpu_architecture":  arch,
-						"version":           "418.84.202109241901-0",
-						"url":               ts.URL() + "/" + arch + ".iso",
+					archVersion := OSImage{
+						OpenshiftVersion: "4.18",
+						CPUArchitecture:  arch,
+						Version:          "418.84.202109241901-0",
+						URL:              ts.URL() + "/" + arch + ".iso",
 					}
 
 					// Provide valid ISO response
@@ -622,18 +623,19 @@ var _ = Context("with a data directory configured", func() {
 						),
 					)
 
-					is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{archVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+					is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{archVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 					Expect(err).NotTo(HaveOccurred())
 
 					// Pre-create nmstatectl cache to avoid actual extraction
-					nmstatectlPath, err := is.NmstatectlPathForParams(archVersion["openshift_version"], archVersion["cpu_architecture"])
+					nmstatectlPath, exists, err := is.NmstatectlPathForParams(archVersion.OpenshiftVersion, archVersion.CPUArchitecture)
 					Expect(err).NotTo(HaveOccurred())
+					Expect(exists).To(BeFalse())
 					cacheContent := fmt.Sprintf("cached-nmstatectl-%s", arch)
 					Expect(os.WriteFile(nmstatectlPath, []byte(cacheContent), 0755)).To(Succeed()) //nolint:gosec
 
 					// Mock minimal ISO creation
-					expectedRootfs := fmt.Sprintf("http://images.example.com/boot-artifacts/rootfs?arch=%s&version=%s", arch, archVersion["version"])
-					mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), expectedRootfs, arch, gomock.Any(), archVersion["openshift_version"], nmstatectlPath).Return(nil)
+					expectedRootfs := fmt.Sprintf("http://images.example.com/boot-artifacts/rootfs?arch=%s&version=%s", arch, archVersion.Version)
+					mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), expectedRootfs, arch, gomock.Any(), archVersion.OpenshiftVersion, nmstatectlPath).Return(nil)
 					// If nmstatectl is cached, BuildNmstateCpioArchive must not be called.
 					mockNmstateHandler.EXPECT().BuildNmstateCpioArchive(gomock.Any()).Times(0)
 					Expect(is.Populate(ctx)).To(Succeed())
@@ -643,10 +645,10 @@ var _ = Context("with a data directory configured", func() {
 				Entry("ppc64le architecture", "ppc64le"),
 			)
 			It("Skip nmstatectl extraction for versions below the minimum supported", func() {
-				oldVersion := map[string]string{
-					"openshift_version": "4.5", // Version that doesn't support nmstatectl
-					"cpu_architecture":  "x86_64",
-					"version":           "45.82.202009222340-0",
+				oldVersion := OSImage{
+					OpenshiftVersion: "4.5", // Version that doesn't support nmstatectl,
+					CPUArchitecture:  "x86_64",
+					Version:          "45.82.202009222340-0",
 				}
 
 				isoContent, isoHeader := readTestISO(validVolumeID)
@@ -656,14 +658,14 @@ var _ = Context("with a data directory configured", func() {
 						ghttp.RespondWith(http.StatusOK, isoContent, isoHeader),
 					),
 				)
-				oldVersion["url"] = ts.URL() + "/old.iso"
-				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{oldVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+				oldVersion.URL = ts.URL() + "/old.iso"
+				is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{oldVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 				Expect(err).NotTo(HaveOccurred())
 
-				nmstatectlPath, err := is.NmstatectlPathForParams(oldVersion["openshift_version"], oldVersion["cpu_architecture"])
+				nmstatectlPath, _, err := is.NmstatectlPathForParams(oldVersion.OpenshiftVersion, oldVersion.CPUArchitecture)
 				Expect(err).NotTo(HaveOccurred())
 
-				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), gomock.Any(), "x86_64", gomock.Any(), oldVersion["openshift_version"], nmstatectlPath).Return(nil)
+				mockEditor.EXPECT().CreateMinimalISOTemplate(gomock.Any(), gomock.Any(), "x86_64", gomock.Any(), oldVersion.OpenshiftVersion, nmstatectlPath).Return(nil)
 				mockNmstateHandler.EXPECT().BuildNmstateCpioArchive(gomock.Any()).Times(0)
 
 				Expect(is.Populate(ctx)).To(Succeed())
@@ -674,11 +676,11 @@ var _ = Context("with a data directory configured", func() {
 
 var _ = Describe("PathForParams", func() {
 	It("creates the correct path when looked up by openshift version", func() {
-		versions := []map[string]string{{
-			"openshift_version": "4.8",
-			"cpu_architecture":  "x86_64",
-			"url":               "http://example.com/image/x86_64-48.iso",
-			"version":           "48.84.202109241901-0",
+		versions := []OSImage{{
+			OpenshiftVersion: "4.8",
+			CPUArchitecture:  "x86_64",
+			URL:              "http://example.com/image/x86_64-48.iso",
+			Version:          "48.84.202109241901-0",
 		}}
 		is, err := NewImageStore(nil, "/tmp/some/dir", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).NotTo(HaveOccurred())
@@ -687,11 +689,11 @@ var _ = Describe("PathForParams", func() {
 	})
 
 	It("creates the correct path when looked up by RHCOS version", func() {
-		versions := []map[string]string{{
-			"openshift_version": "4.8",
-			"cpu_architecture":  "x86_64",
-			"url":               "http://example.com/image/x86_64-48.iso",
-			"version":           "48.84.202109241901-0",
+		versions := []OSImage{{
+			OpenshiftVersion: "4.8",
+			CPUArchitecture:  "x86_64",
+			URL:              "http://example.com/image/x86_64-48.iso",
+			Version:          "48.84.202109241901-0",
 		}}
 		is, err := NewImageStore(nil, "/tmp/some/dir", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).NotTo(HaveOccurred())
@@ -700,26 +702,78 @@ var _ = Describe("PathForParams", func() {
 	})
 })
 
+var _ = Describe("NmstatectlPathForParams", func() {
+	var (
+		dataDir string
+		is      ImageStore
+	)
+
+	BeforeEach(func() {
+		var err error
+		dataDir, err = os.MkdirTemp("", "nmstatectlPathTest")
+		Expect(err).NotTo(HaveOccurred())
+
+		versions := []OSImage{{
+			OpenshiftVersion: "4.18",
+			CPUArchitecture:  "x86_64",
+			URL:              "http://example.com/image/x86_64-418.iso",
+			Version:          "418.94.202410010000-0",
+		}}
+		is, err = NewImageStore(nil, dataDir, imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(dataDir)
+	})
+
+	It("returns the path and exists=false when the file is missing", func() {
+		path, exists, err := is.NmstatectlPathForParams("4.18", "x86_64")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse())
+		Expect(path).To(Equal(filepath.Join(dataDir, "nmstatectl-418.94.202410010000-0-x86_64")))
+	})
+
+	It("returns exists=true when the file is present", func() {
+		path, exists, err := is.NmstatectlPathForParams("4.18", "x86_64")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse())
+		Expect(os.WriteFile(path, []byte("cached"), 0755)).To(Succeed()) //nolint:gosec
+
+		path, exists, err = is.NmstatectlPathForParams("4.18", "x86_64")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue())
+		Expect(path).To(Equal(filepath.Join(dataDir, "nmstatectl-418.94.202410010000-0-x86_64")))
+	})
+
+	It("looks up the path by RHCOS version", func() {
+		path, exists, err := is.NmstatectlPathForParams("418.94.202410010000-0", "x86_64")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse())
+		Expect(path).To(Equal(filepath.Join(dataDir, "nmstatectl-418.94.202410010000-0-x86_64")))
+	})
+})
+
 var _ = Describe("HaveVersion", func() {
 	var (
-		versions = []map[string]string{
+		versions = []OSImage{
 			{
-				"openshift_version": "4.8",
-				"cpu_architecture":  "x86_64",
-				"url":               "http://example.com/image/x86_64-48.iso",
-				"version":           "48.84.202109241901-0",
+				OpenshiftVersion: "4.8",
+				CPUArchitecture:  "x86_64",
+				URL:              "http://example.com/image/x86_64-48.iso",
+				Version:          "48.84.202109241901-0",
 			},
 			{
-				"openshift_version": "4.9",
-				"cpu_architecture":  "arm64",
-				"url":               "http://example.com/image/arm64-49.iso",
-				"version":           "49.84.202110081407-0",
+				OpenshiftVersion: "4.9",
+				CPUArchitecture:  "arm64",
+				URL:              "http://example.com/image/arm64-49.iso",
+				Version:          "49.84.202110081407-0",
 			},
 			{
-				"openshift_version": "4.15",
-				"cpu_architecture":  "s390x",
-				"url":               "http://example.com/image/s390x-415.iso",
-				"version":           "415.92.202403212258-0",
+				OpenshiftVersion: "4.15",
+				CPUArchitecture:  "s390x",
+				URL:              "http://example.com/image/s390x-415.iso",
+				Version:          "415.92.202403212258-0",
 			},
 		}
 		store ImageStore
@@ -756,63 +810,78 @@ var _ = Describe("HaveVersion", func() {
 
 var _ = Describe("deduplicateVersions", func() {
 	It("keeps the entry with the highest openshift_version per RHCOS version and architecture", func() {
-		versions := []map[string]string{
+		versions := []OSImage{
 			{
-				"openshift_version": "4.10",
-				"cpu_architecture":  "x86_64",
-				"url":               "http://example.com/first.iso",
-				"version":           "410.84.202201251210-0",
+				OpenshiftVersion: "4.10",
+				CPUArchitecture:  "x86_64",
+				URL:              "http://example.com/first.iso",
+				Version:          "410.84.202201251210-0",
 			},
 			{
-				"openshift_version": "4.10.1",
-				"cpu_architecture":  "x86_64",
-				"url":               "http://example.com/second.iso",
-				"version":           "410.84.202201251210-0",
+				OpenshiftVersion: "4.10.1",
+				CPUArchitecture:  "x86_64",
+				URL:              "http://example.com/second.iso",
+				Version:          "410.84.202201251210-0",
 			},
 			{
-				"openshift_version": "4.11",
-				"cpu_architecture":  "arm64",
-				"url":               "http://example.com/arm64.iso",
-				"version":           "411.86.202204190940-0",
+				OpenshiftVersion: "4.11",
+				CPUArchitecture:  "arm64",
+				URL:              "http://example.com/arm64.iso",
+				Version:          "411.86.202204190940-0",
 			},
 		}
 		dedupedVersions := deduplicateVersions(versions)
 		Expect(dedupedVersions).To(HaveLen(2))
-		Expect(dedupedVersions).To(ContainElement(HaveKeyWithValue("url", "http://example.com/second.iso")))
-		Expect(dedupedVersions).To(ContainElement(HaveKeyWithValue("openshift_version", "4.10.1")))
+		Expect(dedupedVersions).To(ContainElement(OSImage{
+			OpenshiftVersion: "4.10.1",
+			CPUArchitecture:  "x86_64",
+			URL:              "http://example.com/second.iso",
+			Version:          "410.84.202201251210-0",
+		}))
 	})
 
 	It("keeps 2 entries with the same RHCOS version and architecture but different image types", func() {
-		versions := []map[string]string{
+		versions := []OSImage{
 			{
-				"openshift_version": "4.10",
-				"cpu_architecture":  "x86_64",
-				"url":               "http://example.com/disconnected.iso",
-				"version":           "410.84.202201251210-0",
-				"type":              "disconnected-iso",
+				OpenshiftVersion: "4.10",
+				CPUArchitecture:  "x86_64",
+				URL:              "http://example.com/disconnected.iso",
+				Version:          "410.84.202201251210-0",
+				Type:             "disconnected-iso",
 			},
 			{
-				"openshift_version": "4.10",
-				"cpu_architecture":  "x86_64",
-				"url":               "http://example.com/full.iso",
-				"version":           "410.84.202201251210-0",
+				OpenshiftVersion: "4.10",
+				CPUArchitecture:  "x86_64",
+				URL:              "http://example.com/full.iso",
+				Version:          "410.84.202201251210-0",
 			},
 		}
 		dedupedVersions := deduplicateVersions(versions)
 		Expect(dedupedVersions).To(HaveLen(2))
-		Expect(dedupedVersions).To(ContainElement(HaveKeyWithValue("url", "http://example.com/disconnected.iso")))
-		Expect(dedupedVersions).To(ContainElement(HaveKeyWithValue("url", "http://example.com/full.iso")))
+		Expect(dedupedVersions).To(ContainElement(OSImage{
+			OpenshiftVersion: "4.10",
+			CPUArchitecture:  "x86_64",
+			URL:              "http://example.com/disconnected.iso",
+			Version:          "410.84.202201251210-0",
+			Type:             "disconnected-iso",
+		}))
+		Expect(dedupedVersions).To(ContainElement(OSImage{
+			OpenshiftVersion: "4.10",
+			CPUArchitecture:  "x86_64",
+			URL:              "http://example.com/full.iso",
+			Version:          "410.84.202201251210-0",
+		}))
 	})
 })
 
 var _ = Describe("NewImageStore", func() {
 	It("should not error with valid version", func() {
-		versions := []map[string]string{
+		versions := []OSImage{
 			{
-				"openshift_version": "4.8",
-				"cpu_architecture":  "x86_64",
-				"url":               "http://example.com/image/x86_64-48.iso",
-				"version":           "48.84.202109241901-0",
+				OpenshiftVersion: "4.8",
+				CPUArchitecture:  "x86_64",
+				URL:              "http://example.com/image/x86_64-48.iso",
+				Version:          "48.84.202109241901-0",
 			},
 		}
 		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
@@ -820,7 +889,7 @@ var _ = Describe("NewImageStore", func() {
 	})
 
 	It("should error when RHCOS_IMAGES are not set i.e. versions is an empty slice", func() {
-		versions := []map[string]string{}
+		versions := []OSImage{}
 		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("invalid versions: must not be empty"))
@@ -828,11 +897,11 @@ var _ = Describe("NewImageStore", func() {
 	})
 
 	It("should error when openshift_version is not set", func() {
-		versions := []map[string]string{
+		versions := []OSImage{
 			{
-				"cpu_architecture": "x86_64",
-				"url":              "http://example.com/image/x86_64-48.iso",
-				"version":          "48.84.202109241901-0",
+				CPUArchitecture: "x86_64",
+				URL:             "http://example.com/image/x86_64-48.iso",
+				Version:         "48.84.202109241901-0",
 			},
 		}
 		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
@@ -840,11 +909,11 @@ var _ = Describe("NewImageStore", func() {
 	})
 
 	It("should error when cpu_architecture is not set", func() {
-		versions := []map[string]string{
+		versions := []OSImage{
 			{
-				"openshift_version": "4.8",
-				"url":               "http://example.com/image/x86_64-48.iso",
-				"version":           "48.84.202109241901-0",
+				OpenshiftVersion: "4.8",
+				URL:              "http://example.com/image/x86_64-48.iso",
+				Version:          "48.84.202109241901-0",
 			},
 		}
 		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
@@ -852,11 +921,11 @@ var _ = Describe("NewImageStore", func() {
 	})
 
 	It("should error when url is not set", func() {
-		versions := []map[string]string{
+		versions := []OSImage{
 			{
-				"openshift_version": "4.8",
-				"cpu_architecture":  "x86_64",
-				"version":           "48.84.202109241901-0",
+				OpenshiftVersion: "4.8",
+				CPUArchitecture:  "x86_64",
+				Version:          "48.84.202109241901-0",
 			},
 		}
 		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
@@ -864,15 +933,31 @@ var _ = Describe("NewImageStore", func() {
 	})
 
 	It("should error when version is not set", func() {
-		versions := []map[string]string{
+		versions := []OSImage{
 			{
-				"openshift_version": "4.8",
-				"cpu_architecture":  "x86_64",
-				"url":               "http://example.com/image/x86_64-48.iso",
+				OpenshiftVersion: "4.8",
+				CPUArchitecture:  "x86_64",
+				URL:              "http://example.com/image/x86_64-48.iso",
 			},
 		}
 		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("accepts stream metadata including boolean default_os_stream", func() {
+		defaultStream := true
+		versions := []OSImage{
+			{
+				OpenshiftVersion: "4.19",
+				CPUArchitecture:  "x86_64",
+				URL:              "http://example.com/image.iso",
+				Version:          "419.94.202501010000-0",
+				OsStream:         "rhel-9",
+				DefaultOsStream:  &defaultStream,
+			},
+		}
+		_, err := NewImageStore(nil, "", imageServiceBaseURL, false, versions, "", map[string]string{}, map[string]string{}, nil)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })
 
@@ -1020,30 +1105,30 @@ var _ = Context("cleanDataDir", func() {
 	})
 
 	It("preserves nmstatectl cached files for all architectures", func() {
-		versions := []map[string]string{
+		versions := []OSImage{
 			{
-				"openshift_version": "4.18",
-				"cpu_architecture":  "x86_64",
-				"url":               "http://example.com/image/x86_64-418.iso",
-				"version":           "418.84.202109241901-0",
+				OpenshiftVersion: "4.18",
+				CPUArchitecture:  "x86_64",
+				URL:              "http://example.com/image/x86_64-418.iso",
+				Version:          "418.84.202109241901-0",
 			},
 			{
-				"openshift_version": "4.18",
-				"cpu_architecture":  "s390x",
-				"url":               "http://example.com/image/s390x-418.iso",
-				"version":           "418.92.202403212258-0",
+				OpenshiftVersion: "4.18",
+				CPUArchitecture:  "s390x",
+				URL:              "http://example.com/image/s390x-418.iso",
+				Version:          "418.92.202403212258-0",
 			},
 			{
-				"openshift_version": "4.18",
-				"cpu_architecture":  "arm64",
-				"url":               "http://example.com/image/arm64-418.iso",
-				"version":           "418.84.202109241901-0",
+				OpenshiftVersion: "4.18",
+				CPUArchitecture:  "arm64",
+				URL:              "http://example.com/image/arm64-418.iso",
+				Version:          "418.84.202109241901-0",
 			},
 			{
-				"openshift_version": "4.18",
-				"cpu_architecture":  "ppc64le",
-				"url":               "http://example.com/image/ppc64le-418.iso",
-				"version":           "418.84.202109241901-0",
+				OpenshiftVersion: "4.18",
+				CPUArchitecture:  "ppc64le",
+				URL:              "http://example.com/image/ppc64le-418.iso",
+				Version:          "418.84.202109241901-0",
 			},
 		}
 
@@ -1156,12 +1241,12 @@ var _ = Describe("Populate with disconnected ISO", func() {
 		})
 
 		It("downloads disconnected ISO without creating minimal ISO", func() {
-			disconnectedVersion := map[string]string{
-				"openshift_version": "4.8",
-				"cpu_architecture":  "x86_64",
-				"url":               ts.URL() + "/disconnected.iso",
-				"version":           "48.84.202109241901-0",
-				"type":              ImageTypeDisconnectedIso,
+			disconnectedVersion := OSImage{
+				OpenshiftVersion: "4.8",
+				CPUArchitecture:  "x86_64",
+				URL:              ts.URL() + "/disconnected.iso",
+				Version:          "48.84.202109241901-0",
+				Type:             ImageTypeDisconnectedIso,
 			}
 
 			validVolumeID := "rhcos-48.84.202109241901-0"
@@ -1180,7 +1265,7 @@ var _ = Describe("Populate with disconnected ISO", func() {
 				),
 			)
 
-			is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{disconnectedVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+			is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{disconnectedVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = is.Populate(ctx)
@@ -1192,15 +1277,15 @@ var _ = Describe("Populate with disconnected ISO", func() {
 		})
 
 		It("fails when invalid image type is specified", func() {
-			invalidVersion := map[string]string{
-				"openshift_version": "4.8",
-				"cpu_architecture":  "x86_64",
-				"url":               ts.URL() + "/invalid.iso",
-				"version":           "48.84.202109241901-0",
-				"type":              "invalid-type",
+			invalidVersion := OSImage{
+				OpenshiftVersion: "4.8",
+				CPUArchitecture:  "x86_64",
+				URL:              ts.URL() + "/invalid.iso",
+				Version:          "48.84.202109241901-0",
+				Type:             "invalid-type",
 			}
 
-			is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []map[string]string{invalidVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
+			is, err := NewImageStore(mockEditor, dataDir, imageServiceBaseURL, false, []OSImage{invalidVersion}, "", osImageDownloadHeadersMap, osImageDownloadQueryParamsMap, mockNmstateHandler)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = is.Populate(ctx)

--- a/pkg/imagestore/mock_imagestore.go
+++ b/pkg/imagestore/mock_imagestore.go
@@ -55,12 +55,13 @@ func (mr *MockImageStoreMockRecorder) HaveVersion(version, arch any) *gomock.Cal
 }
 
 // NmstatectlPathForParams mocks base method.
-func (m *MockImageStore) NmstatectlPathForParams(openshiftVersion, arch string) (string, error) {
+func (m *MockImageStore) NmstatectlPathForParams(openshiftVersion, arch string) (string, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NmstatectlPathForParams", openshiftVersion, arch)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // NmstatectlPathForParams indicates an expected call of NmstatectlPathForParams.


### PR DESCRIPTION
## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->

We currently treat an OS Image as a map from string to string, but on assisted-service we're going to include a non-string field to the OS Image struct which would break the existing code.

Also because the version initrd receives can be the RHCOS version we can't directly compare it with the minimum openshift version where we include nmstatectl. Instead we'll rely on the fact that the imagestore will only create the nmstatectl for OS Images with openshift versions that are at least the minimum. So in initrd, if nmstatectl exists for the version we'll include it.

## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->

Deployed with RHCOS_VERSIONS including the new fields and checking that versions that should include nmstatectl include it while versions that shouldn't don't. 

## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->

Closes [MGMT-25140](https://redhat.atlassian.net/browse/MGMT-25140)

## Checklist

- [x] Title and description added to both, commit and PR
- [x] Relevant issues have been associated
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit tests (note that code changes require unit tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nmstate image detection by checking whether the required cached artifact exists.
  * Preserved clear server errors when nmstate image lookup fails.

* **Improvements**
  * Improved handling of OS image metadata, including image types and stream information.
  * Enhanced image cache lookup and cleanup behavior.

* **Tests**
  * Expanded coverage for typed OS image data, cache existence, stream metadata, and nmstate scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->