### PR TITLE
APPSRE-14688: remove legacy monitoring.coreos.com/v1 ServiceMonitor

### DIFF
--- a/deploy/template-monitoring.yaml
+++ b/deploy/template-monitoring.yaml
@@ -8,24 +8,6 @@ kind: Template
 metadata:
   name: assisted-image-service-monitoring
 objects:
-- apiVersion: monitoring.coreos.com/v1
-  kind: ServiceMonitor
-  metadata:
-    labels:
-      prometheus: app-sre
-    name: servicemonitor-image-service
-  spec:
-    endpoints:
-    - interval: 30s
-      path: /metrics
-      port: image-service
-      scheme: http
-    namespaceSelector:
-      matchNames:
-      - ${NAMESPACE}
-    selector:
-      matchLabels:
-        name: assisted-image-service
 - apiVersion: monitoring.rhobs/v1
   kind: ServiceMonitor
   metadata:


### PR DESCRIPTION
## Summary
- Removes the legacy `monitoring.coreos.com/v1` ServiceMonitor (`servicemonitor-image-service`) from `deploy/template-monitoring.yaml`, keeping only the `monitoring.rhobs/v1` companion (`servicemonitor-image-service-coo`) added for APPSRE-14333.
- COO Prometheus scraping of `assisted-image-service` via the `monitoring.rhobs/v1` ServiceMonitor has been confirmed healthy.

## Test plan
- [ ] Confirm app-interface reconcile deletes the legacy `ServiceMonitor.monitoring.coreos.com` object from the assisted-installer namespaces after this merges
- [ ] Confirm COO Prometheus continues scraping `up{job="assisted-image-service"}` with no gap

Relates to: https://redhat.atlassian.net/browse/APPSRE-14688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OpenShift monitoring configuration to use the supported ServiceMonitor resource, improving compatibility with the current monitoring setup.
  * Removed deployment of the legacy ServiceMonitor configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->