### PR TITLE
NO-ISSUE: some images are behind proxy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -133,9 +133,24 @@ parameters:
   value: "6Gi"
 - name: PDB_MIN_AVAILABLE
   value: "2"
-- name: OS_IMAGES_REQUEST_HEADERS
-  value: ''
-  required: false
+- name: OS_IMAGES_REQUEST_HEADERS_SECRET_NAME
+  value: assisted-image-service-os-images-request-headers
+  description: Secret containing OS_IMAGES_REQUEST_HEADERS; must be created outside this template
+- name: OS_IMAGES_REQUEST_HEADERS_SECRET_KEY
+  value: OS_IMAGES_REQUEST_HEADERS
+  description: Key in OS_IMAGES_REQUEST_HEADERS_SECRET_NAME for OS_IMAGES_REQUEST_HEADERS
+- name: PROXY_SECRET_NAME
+  value: assisted-image-service-proxy
+  description: Secret containing proxy env vars; must be created outside this template
+- name: HTTP_PROXY_SECRET_KEY
+  value: HTTP_PROXY
+  description: Key in PROXY_SECRET_NAME for HTTP_PROXY
+- name: HTTPS_PROXY_SECRET_KEY
+  value: HTTPS_PROXY
+  description: Key in PROXY_SECRET_NAME for HTTPS_PROXY
+- name: NO_PROXY_SECRET_KEY
+  value: NO_PROXY
+  description: Key in PROXY_SECRET_NAME for NO_PROXY
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -180,8 +195,6 @@ objects:
             value: "8080"
           - name: RHCOS_VERSIONS
             value: ${OS_IMAGES}
-          - name: OS_IMAGES_REQUEST_HEADERS
-            value: ${OS_IMAGES_REQUEST_HEADERS}
           - name: ASSISTED_SERVICE_SCHEME
             value: http
           - name: ASSISTED_SERVICE_HOST
@@ -194,6 +207,30 @@ objects:
             value: "/data"
           - name: DATA_TEMP_DIR
             value: "/data_temp"
+          - name: OS_IMAGES_REQUEST_HEADERS
+            valueFrom:
+              secretKeyRef:
+                name: ${OS_IMAGES_REQUEST_HEADERS_SECRET_NAME}
+                key: ${OS_IMAGES_REQUEST_HEADERS_SECRET_KEY}
+                optional: true
+          - name: HTTP_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: ${PROXY_SECRET_NAME}
+                key: ${HTTP_PROXY_SECRET_KEY}
+                optional: true
+          - name: HTTPS_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: ${PROXY_SECRET_NAME}
+                key: ${HTTPS_PROXY_SECRET_KEY}
+                optional: true
+          - name: NO_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: ${PROXY_SECRET_NAME}
+                key: ${NO_PROXY_SECRET_KEY}
+                optional: true
           ports:
           - protocol: TCP
             containerPort: 8080


### PR DESCRIPTION
Passing http proxy parameters is crucial now for accessing some OVE images pre-release

## Description
<!--
Include a summary of the change as well as the reasoning behind it including any additional context.
You can refer to the [Kubernetes community documentation](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines) on writing good commit messages, which provides good tips and ideas.
-->


## How was this code tested?
<!--
Describe how the change was tested if manual tests were required.
If manual tests were not required, explain why
-->


## Assignees
<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Links
<!--
List any applicable links to related PRs or issues
-->


## Checklist

- [ ] Title and description added to both, commit and PR
- [ ] Relevant issues have been associated
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit tests (note that code changes require unit tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Secret-backed configuration for image request headers and proxy settings during deployment.
  - Supports separate HTTP, HTTPS, and no-proxy values through configurable Secret keys.
  - Allows deployments to provide these settings without embedding sensitive values directly in the deployment configuration.

- **Configuration**
  - Replaced direct image request header and proxy template values with optional Secret references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->